### PR TITLE
feat: Phase 1.4 - Basic node type implementations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",
+    "pytest-httpx>=0.30.0",
     "ruff>=0.1.0",
     "mypy>=1.7.0",
     "types-PyYAML>=6.0.0",

--- a/src/flowpilot/engine/nodes/__init__.py
+++ b/src/flowpilot/engine/nodes/__init__.py
@@ -1,0 +1,15 @@
+"""Node executor implementations for FlowPilot."""
+
+from .condition import ConditionExecutor
+from .file_read import FileReadExecutor
+from .file_write import FileWriteExecutor
+from .http import HttpExecutor
+from .shell import ShellExecutor
+
+__all__ = [
+    "ConditionExecutor",
+    "FileReadExecutor",
+    "FileWriteExecutor",
+    "HttpExecutor",
+    "ShellExecutor",
+]

--- a/src/flowpilot/engine/nodes/condition.py
+++ b/src/flowpilot/engine/nodes/condition.py
@@ -1,0 +1,138 @@
+"""Condition node executor for FlowPilot."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import ConditionNode
+
+
+@ExecutorRegistry.register("condition")
+class ConditionExecutor(NodeExecutor):
+    """Evaluate conditions and determine next node."""
+
+    async def execute(
+        self,
+        node: ConditionNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Evaluate a condition and return the next node to execute.
+
+        Args:
+            node: The condition node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with condition result and next node.
+        """
+        started_at = datetime.now()
+
+        try:
+            # Get template context for evaluation
+            ctx = context.get_template_context()
+
+            # Safely evaluate the condition
+            result = self._safe_eval(node.if_expr, ctx)
+
+            # Determine next node
+            next_node = node.then if result else node.else_node
+
+            return NodeResult(
+                status="success",
+                output=str(result),
+                data={
+                    "condition": node.if_expr,
+                    "result": bool(result),
+                    "next_node": next_node,
+                },
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+        except ValueError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Condition evaluation failed: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Condition error: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    def _safe_eval(self, expr: str, context: dict[str, Any]) -> bool:
+        """Safely evaluate a Python expression.
+
+        Args:
+            expr: The expression to evaluate.
+            context: Context dictionary for variable access.
+
+        Returns:
+            Boolean result of the expression.
+
+        Raises:
+            ValueError: If expression uses disallowed names.
+        """
+        # Define allowed built-in names
+        allowed_names: dict[str, Any] = {
+            # Boolean and None
+            "True": True,
+            "False": False,
+            "None": None,
+            # Type conversions
+            "len": len,
+            "str": str,
+            "int": int,
+            "float": float,
+            "bool": bool,
+            "list": list,
+            "dict": dict,
+            # Collection operations
+            "any": any,
+            "all": all,
+            "sum": sum,
+            "min": min,
+            "max": max,
+            "abs": abs,
+            # String operations
+            "lower": str.lower,
+            "upper": str.upper,
+            # Context variables
+            **context,
+        }
+
+        # Compile the expression
+        try:
+            code = compile(expr, "<condition>", "eval")
+        except SyntaxError as e:
+            raise ValueError(f"Invalid syntax: {e}") from e
+
+        # Check for disallowed names
+        for name in code.co_names:
+            if name not in allowed_names:
+                raise ValueError(f"Name '{name}' is not allowed in conditions")
+
+        # Evaluate with restricted builtins
+        try:
+            result = eval(code, {"__builtins__": {}}, allowed_names)
+            return bool(result)
+        except Exception as e:
+            raise ValueError(f"Evaluation failed: {e}") from e
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/engine/nodes/file_read.py
+++ b/src/flowpilot/engine/nodes/file_read.py
@@ -1,0 +1,101 @@
+"""File read node executor for FlowPilot."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import FileReadNode
+
+
+@ExecutorRegistry.register("file-read")
+class FileReadExecutor(NodeExecutor):
+    """Read file contents."""
+
+    async def execute(
+        self,
+        node: FileReadNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Read contents of a file.
+
+        Args:
+            node: The file read node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with file contents.
+        """
+        started_at = datetime.now()
+
+        # Expand path
+        path = self._expand_path(node.path)
+
+        try:
+            # Read file content
+            content = path.read_text(encoding=node.encoding)
+            stat = path.stat()
+
+            return NodeResult(
+                status="success",
+                output=content,
+                data={
+                    "path": str(path),
+                    "size": stat.st_size,
+                    "lines": len(content.splitlines()),
+                },
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+        except FileNotFoundError:
+            return NodeResult(
+                status="error",
+                error_message=f"File not found: {path}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except PermissionError:
+            return NodeResult(
+                status="error",
+                error_message=f"Permission denied: {path}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except UnicodeDecodeError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Encoding error ({node.encoding}): {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=str(e),
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    @staticmethod
+    def _expand_path(path: str) -> Path:
+        """Expand ~ and environment variables in path."""
+        expanded = os.path.expandvars(os.path.expanduser(path))
+        return Path(expanded)
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/engine/nodes/file_write.py
+++ b/src/flowpilot/engine/nodes/file_write.py
@@ -1,0 +1,101 @@
+"""File write node executor for FlowPilot."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import FileWriteNode
+
+
+@ExecutorRegistry.register("file-write")
+class FileWriteExecutor(NodeExecutor):
+    """Write content to files."""
+
+    async def execute(
+        self,
+        node: FileWriteNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Write content to a file.
+
+        Args:
+            node: The file write node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with file path.
+        """
+        started_at = datetime.now()
+
+        # Expand path
+        path = self._expand_path(node.path)
+
+        try:
+            # Create parent directories if needed
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Write content based on mode
+            if node.mode == "append":
+                with open(path, "a", encoding=node.encoding) as f:
+                    f.write(node.content)
+            else:
+                path.write_text(node.content, encoding=node.encoding)
+
+            stat = path.stat()
+
+            return NodeResult(
+                status="success",
+                output=str(path),
+                data={
+                    "path": str(path),
+                    "size": stat.st_size,
+                    "mode": node.mode,
+                },
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+        except PermissionError:
+            return NodeResult(
+                status="error",
+                error_message=f"Permission denied: {path}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except OSError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"OS error writing file: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=str(e),
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    @staticmethod
+    def _expand_path(path: str) -> Path:
+        """Expand ~ and environment variables in path."""
+        expanded = os.path.expandvars(os.path.expanduser(path))
+        return Path(expanded)
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/engine/nodes/http.py
+++ b/src/flowpilot/engine/nodes/http.py
@@ -1,0 +1,121 @@
+"""HTTP node executor for FlowPilot."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import HttpNode
+
+
+@ExecutorRegistry.register("http")
+class HttpExecutor(NodeExecutor):
+    """Execute HTTP requests."""
+
+    async def execute(
+        self,
+        node: HttpNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Execute an HTTP request.
+
+        Args:
+            node: The HTTP node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with response data.
+        """
+        started_at = datetime.now()
+
+        try:
+            async with httpx.AsyncClient(timeout=node.timeout) as client:
+                # Prepare request body
+                content: str | None = None
+                json_body: dict[str, Any] | None = None
+
+                if node.body is not None:
+                    if isinstance(node.body, dict):
+                        json_body = node.body
+                    else:
+                        content = str(node.body)
+
+                # Make request
+                response = await client.request(
+                    method=node.method,
+                    url=node.url,
+                    headers=node.headers,
+                    content=content,
+                    json=json_body,
+                )
+
+                # Try to parse JSON response
+                response_data: dict[str, Any]
+                try:
+                    response_data = response.json()
+                except Exception:
+                    response_data = {"text": response.text}
+
+                # Build result
+                data = {
+                    "status_code": response.status_code,
+                    "headers": dict(response.headers),
+                    "body": response_data,
+                }
+
+                if response.is_success:
+                    return NodeResult(
+                        status="success",
+                        output=response.text,
+                        data=data,
+                        duration_ms=self._duration_ms(started_at),
+                        started_at=started_at,
+                        finished_at=datetime.now(),
+                    )
+                else:
+                    return NodeResult(
+                        status="error",
+                        output=response.text,
+                        data=data,
+                        error_message=f"HTTP {response.status_code}: {response.reason_phrase}",
+                        duration_ms=self._duration_ms(started_at),
+                        started_at=started_at,
+                        finished_at=datetime.now(),
+                    )
+
+        except httpx.TimeoutException:
+            return NodeResult(
+                status="error",
+                error_message=f"Request timed out after {node.timeout}s",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except httpx.ConnectError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Connection failed: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=str(e),
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/engine/nodes/shell.py
+++ b/src/flowpilot/engine/nodes/shell.py
@@ -1,0 +1,127 @@
+"""Shell node executor for FlowPilot."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import ShellNode
+
+
+@ExecutorRegistry.register("shell")
+class ShellExecutor(NodeExecutor):
+    """Execute shell commands."""
+
+    async def execute(
+        self,
+        node: ShellNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Execute a shell command.
+
+        Args:
+            node: The shell node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with command output.
+        """
+        started_at = datetime.now()
+
+        # Expand paths and prepare environment
+        working_dir = self._expand_path(node.working_dir) if node.working_dir else None
+        env = {**os.environ, **node.env}
+
+        try:
+            # Create subprocess
+            proc = await asyncio.create_subprocess_shell(
+                node.command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=working_dir,
+                env=env,
+            )
+
+            # Wait for completion with timeout
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(),
+                    timeout=node.timeout,
+                )
+            except TimeoutError:
+                # Kill the process on timeout
+                proc.kill()
+                await proc.wait()
+                return NodeResult(
+                    status="error",
+                    error_message=f"Command timed out after {node.timeout}s",
+                    duration_ms=self._duration_ms(started_at),
+                    started_at=started_at,
+                    finished_at=datetime.now(),
+                )
+
+            # Decode output
+            stdout = stdout_bytes.decode("utf-8", errors="replace")
+            stderr = stderr_bytes.decode("utf-8", errors="replace")
+            exit_code = proc.returncode or 0
+
+            # Build result
+            if exit_code == 0:
+                return NodeResult(
+                    status="success",
+                    stdout=stdout,
+                    stderr=stderr,
+                    output=stdout.strip(),
+                    data={"exit_code": exit_code},
+                    duration_ms=self._duration_ms(started_at),
+                    started_at=started_at,
+                    finished_at=datetime.now(),
+                )
+            else:
+                return NodeResult(
+                    status="error",
+                    stdout=stdout,
+                    stderr=stderr,
+                    output=stdout.strip(),
+                    data={"exit_code": exit_code},
+                    error_message=f"Command exited with code {exit_code}",
+                    duration_ms=self._duration_ms(started_at),
+                    started_at=started_at,
+                    finished_at=datetime.now(),
+                )
+
+        except FileNotFoundError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Working directory not found: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=str(e),
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    @staticmethod
+    def _expand_path(path: str) -> Path:
+        """Expand ~ and environment variables in path."""
+        expanded = os.path.expandvars(os.path.expanduser(path))
+        return Path(expanded)
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/models/nodes.py
+++ b/src/flowpilot/models/nodes.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BaseNode(BaseModel):
     """Base class for all workflow nodes."""
+
+    model_config = ConfigDict(populate_by_name=True)
 
     id: str = Field(
         ...,

--- a/tests/test_nodes_condition.py
+++ b/tests/test_nodes_condition.py
@@ -1,0 +1,527 @@
+"""Tests for condition node executor."""
+
+import pytest
+
+from flowpilot.engine import ExecutionContext
+from flowpilot.engine.nodes import ConditionExecutor
+from flowpilot.models import ConditionNode
+
+
+@pytest.fixture
+def executor() -> ConditionExecutor:
+    """Create a condition executor instance."""
+    return ConditionExecutor()
+
+
+@pytest.fixture
+def context() -> ExecutionContext:
+    """Create an execution context."""
+    return ExecutionContext(workflow_name="test")
+
+
+class TestConditionExecutor:
+    """Tests for ConditionExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_simple_true_condition(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test a simple True condition."""
+        node = ConditionNode(
+            type="condition",
+            id="true-test",
+            if_expr="True",
+            then="then-node",
+            else_node="else-node",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == "True"
+        assert result.data["result"] is True
+        assert result.data["next_node"] == "then-node"
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_simple_false_condition(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test a simple False condition."""
+        node = ConditionNode(
+            type="condition",
+            id="false-test",
+            if_expr="False",
+            then="then-node",
+            else_node="else-node",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == "False"
+        assert result.data["result"] is False
+        assert result.data["next_node"] == "else-node"
+
+    @pytest.mark.asyncio
+    async def test_comparison_greater_than(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test greater than comparison."""
+        node = ConditionNode(
+            type="condition",
+            id="gt-test",
+            if_expr="10 > 5",
+            then="greater",
+            else_node="not-greater",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+        assert result.data["next_node"] == "greater"
+
+    @pytest.mark.asyncio
+    async def test_comparison_less_than(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test less than comparison."""
+        node = ConditionNode(
+            type="condition",
+            id="lt-test",
+            if_expr="3 < 5",
+            then="less",
+            else_node="not-less",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+        assert result.data["next_node"] == "less"
+
+    @pytest.mark.asyncio
+    async def test_comparison_equality(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test equality comparison."""
+        node = ConditionNode(
+            type="condition",
+            id="eq-test",
+            if_expr="5 == 5",
+            then="equal",
+            else_node="not-equal",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+        assert result.data["next_node"] == "equal"
+
+    @pytest.mark.asyncio
+    async def test_string_comparison(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test string comparison."""
+        node = ConditionNode(
+            type="condition",
+            id="string-test",
+            if_expr="'hello' == 'hello'",
+            then="match",
+            else_node="no-match",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_len_function(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test len() function is allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="len-test",
+            if_expr="len('hello') == 5",
+            then="correct",
+            else_node="wrong",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_operations(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test list operations are allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="list-test",
+            if_expr="len([1, 2, 3]) > 2",
+            then="valid",
+            else_node="invalid",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_any_all_functions(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test any() and all() functions are allowed."""
+        # Test any()
+        node = ConditionNode(
+            type="condition",
+            id="any-test",
+            if_expr="any([False, True, False])",
+            then="has-true",
+            else_node="all-false",
+        )
+        result = await executor.execute(node, context)
+        assert result.data["result"] is True
+
+        # Test all()
+        node = ConditionNode(
+            type="condition",
+            id="all-test",
+            if_expr="all([True, True, True])",
+            then="all-true",
+            else_node="has-false",
+        )
+        result = await executor.execute(node, context)
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_min_max_sum_functions(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test min(), max(), sum() functions are allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="math-test",
+            if_expr="sum([1, 2, 3]) == 6 and min([1, 2, 3]) == 1 and max([1, 2, 3]) == 3",
+            then="correct",
+            else_node="wrong",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_type_conversion_functions(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test type conversion functions are allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="type-test",
+            if_expr="int('42') == 42 and str(42) == '42' and float('3.14') > 3",
+            then="correct",
+            else_node="wrong",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_bool_function(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test bool() function is allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="bool-test",
+            if_expr="bool(1) and not bool(0)",
+            then="correct",
+            else_node="wrong",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_abs_function(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test abs() function is allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="abs-test",
+            if_expr="abs(-5) == 5",
+            then="correct",
+            else_node="wrong",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_none_comparison(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test None comparison is allowed."""
+        node = ConditionNode(
+            type="condition",
+            id="none-test",
+            if_expr="None is None",
+            then="is-none",
+            else_node="not-none",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_context_variable_access(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test accessing context variables."""
+        # Add a node result to context
+        from flowpilot.engine.context import NodeResult
+
+        context.set_node_result(
+            "previous",
+            NodeResult.success(output="42", data={"value": 42}),
+        )
+
+        node = ConditionNode(
+            type="condition",
+            id="context-test",
+            if_expr="nodes['previous']['output'] == '42'",
+            then="match",
+            else_node="no-match",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_context_data_access(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test accessing data from previous node."""
+        from flowpilot.engine.context import NodeResult
+
+        # Note: node IDs with hyphens are converted to underscores in template context
+        context.set_node_result(
+            "api-call",
+            NodeResult.success(
+                output="response",
+                data={"status_code": 200, "body": {"success": True}},
+            ),
+        )
+
+        node = ConditionNode(
+            type="condition",
+            id="data-test",
+            if_expr="nodes['api_call']['data']['status_code'] == 200",
+            then="success",
+            else_node="failure",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+        assert result.data["next_node"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_disallowed_name_import(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test that import is disallowed."""
+        node = ConditionNode(
+            type="condition",
+            id="import-test",
+            if_expr="__import__('os').system('ls')",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not allowed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_name_open(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test that open is disallowed."""
+        node = ConditionNode(
+            type="condition",
+            id="open-test",
+            if_expr="open('/etc/passwd')",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not allowed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_name_eval(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test that eval is disallowed."""
+        node = ConditionNode(
+            type="condition",
+            id="eval-test",
+            if_expr="eval('1+1')",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not allowed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_name_exec(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test that exec is disallowed."""
+        node = ConditionNode(
+            type="condition",
+            id="exec-test",
+            if_expr="exec('x=1')",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not allowed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_syntax_error(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test handling of syntax errors."""
+        node = ConditionNode(
+            type="condition",
+            id="syntax-test",
+            if_expr="if True then 1",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "syntax" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_runtime_error(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test handling of runtime errors."""
+        node = ConditionNode(
+            type="condition",
+            id="runtime-test",
+            if_expr="1 / 0",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+
+    @pytest.mark.asyncio
+    async def test_undefined_variable(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test accessing undefined variable."""
+        node = ConditionNode(
+            type="condition",
+            id="undefined-test",
+            if_expr="undefined_var == 1",
+            then="should-fail",
+            else_node="should-fail",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not allowed" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_complex_boolean_expression(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test complex boolean expressions."""
+        node = ConditionNode(
+            type="condition",
+            id="complex-test",
+            if_expr="(5 > 3 and 10 < 20) or (1 == 2)",
+            then="valid",
+            else_node="invalid",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_in_operator(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test 'in' operator."""
+        node = ConditionNode(
+            type="condition",
+            id="in-test",
+            if_expr="'hello' in 'hello world'",
+            then="found",
+            else_node="not-found",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_membership(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test list membership check."""
+        node = ConditionNode(
+            type="condition",
+            id="membership-test",
+            if_expr="3 in [1, 2, 3, 4, 5]",
+            then="found",
+            else_node="not-found",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["result"] is True
+
+    @pytest.mark.asyncio
+    async def test_condition_stores_expression(
+        self, executor: ConditionExecutor, context: ExecutionContext
+    ) -> None:
+        """Test that the original expression is stored in result."""
+        node = ConditionNode(
+            type="condition",
+            id="expr-test",
+            if_expr="10 >= 5",
+            then="yes",
+            else_node="no",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["condition"] == "10 >= 5"
+

--- a/tests/test_nodes_file.py
+++ b/tests/test_nodes_file.py
@@ -1,0 +1,424 @@
+"""Tests for file read and write node executors."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from flowpilot.engine import ExecutionContext
+from flowpilot.engine.nodes import FileReadExecutor, FileWriteExecutor
+from flowpilot.models import FileReadNode, FileWriteNode
+
+
+@pytest.fixture
+def read_executor() -> FileReadExecutor:
+    """Create a file read executor instance."""
+    return FileReadExecutor()
+
+
+@pytest.fixture
+def write_executor() -> FileWriteExecutor:
+    """Create a file write executor instance."""
+    return FileWriteExecutor()
+
+
+@pytest.fixture
+def context() -> ExecutionContext:
+    """Create an execution context."""
+    return ExecutionContext(workflow_name="test")
+
+
+class TestFileReadExecutor:
+    """Tests for FileReadExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_read_simple_file(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading a simple text file."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Hello, World!")
+
+        node = FileReadNode(
+            type="file-read",
+            id="read-test",
+            path=str(test_file),
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == "Hello, World!"
+        assert result.data["path"] == str(test_file)
+        assert result.data["size"] == 13
+        assert result.data["lines"] == 1
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_read_multiline_file(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading a multiline file."""
+        test_file = tmp_path / "multiline.txt"
+        content = "Line 1\nLine 2\nLine 3\nLine 4"
+        test_file.write_text(content)
+
+        node = FileReadNode(
+            type="file-read",
+            id="multiline-read",
+            path=str(test_file),
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == content
+        assert result.data["lines"] == 4
+
+    @pytest.mark.asyncio
+    async def test_read_empty_file(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading an empty file."""
+        test_file = tmp_path / "empty.txt"
+        test_file.write_text("")
+
+        node = FileReadNode(
+            type="file-read",
+            id="empty-read",
+            path=str(test_file),
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == ""
+        assert result.data["size"] == 0
+        assert result.data["lines"] == 0
+
+    @pytest.mark.asyncio
+    async def test_read_file_not_found(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading a non-existent file."""
+        node = FileReadNode(
+            type="file-read",
+            id="not-found-read",
+            path=str(tmp_path / "nonexistent.txt"),
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "not found" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_with_custom_encoding(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading a file with custom encoding."""
+        test_file = tmp_path / "latin1.txt"
+        content = "Héllo Wörld"
+        test_file.write_text(content, encoding="latin-1")
+
+        node = FileReadNode(
+            type="file-read",
+            id="encoding-read",
+            path=str(test_file),
+            encoding="latin-1",
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == content
+
+    @pytest.mark.asyncio
+    async def test_read_encoding_error(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test reading a file with wrong encoding."""
+        test_file = tmp_path / "binary.txt"
+        # Write some bytes that aren't valid UTF-8
+        test_file.write_bytes(b"\xff\xfe\x00\x01")
+
+        node = FileReadNode(
+            type="file-read",
+            id="encoding-error-read",
+            path=str(test_file),
+            encoding="utf-8",
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "encoding" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_path_expansion_tilde(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+    ) -> None:
+        """Test ~ expansion in file path."""
+        # We can't easily test this without creating files in home dir
+        # So we just test that the path gets expanded
+        node = FileReadNode(
+            type="file-read",
+            id="tilde-read",
+            path="~/nonexistent_test_file_12345.txt",
+        )
+        result = await read_executor.execute(node, context)
+
+        # Should fail with file not found (not path error)
+        assert result.status == "error"
+        assert "not found" in result.error_message.lower()
+        # The error message should contain expanded path, not ~
+        assert "~" not in result.error_message or os.path.expanduser("~") in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_read_path_expansion_env_var(
+        self,
+        read_executor: FileReadExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test environment variable expansion in file path."""
+        test_file = tmp_path / "env_test.txt"
+        test_file.write_text("env content")
+
+        monkeypatch.setenv("TEST_DIR", str(tmp_path))
+
+        node = FileReadNode(
+            type="file-read",
+            id="env-read",
+            path="$TEST_DIR/env_test.txt",
+        )
+        result = await read_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == "env content"
+
+
+class TestFileWriteExecutor:
+    """Tests for FileWriteExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_write_simple_file(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test writing a simple text file."""
+        test_file = tmp_path / "output.txt"
+
+        node = FileWriteNode(
+            type="file-write",
+            id="write-test",
+            path=str(test_file),
+            content="Hello, FlowPilot!",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.output == str(test_file)
+        assert result.data["path"] == str(test_file)
+        assert result.data["mode"] == "write"
+        assert test_file.read_text() == "Hello, FlowPilot!"
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_write_creates_parent_directories(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test that parent directories are created."""
+        test_file = tmp_path / "nested" / "deep" / "output.txt"
+
+        node = FileWriteNode(
+            type="file-write",
+            id="nested-write",
+            path=str(test_file),
+            content="Nested content",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert test_file.exists()
+        assert test_file.read_text() == "Nested content"
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites_existing(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test that existing file is overwritten in write mode."""
+        test_file = tmp_path / "existing.txt"
+        test_file.write_text("Original content")
+
+        node = FileWriteNode(
+            type="file-write",
+            id="overwrite-test",
+            path=str(test_file),
+            content="New content",
+            mode="write",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert test_file.read_text() == "New content"
+
+    @pytest.mark.asyncio
+    async def test_write_append_mode(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test appending to existing file."""
+        test_file = tmp_path / "append.txt"
+        test_file.write_text("Original")
+
+        node = FileWriteNode(
+            type="file-write",
+            id="append-test",
+            path=str(test_file),
+            content=" appended",
+            mode="append",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["mode"] == "append"
+        assert test_file.read_text() == "Original appended"
+
+    @pytest.mark.asyncio
+    async def test_write_append_creates_new_file(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test append mode creates file if it doesn't exist."""
+        test_file = tmp_path / "new_append.txt"
+
+        node = FileWriteNode(
+            type="file-write",
+            id="new-append-test",
+            path=str(test_file),
+            content="First content",
+            mode="append",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert test_file.read_text() == "First content"
+
+    @pytest.mark.asyncio
+    async def test_write_with_custom_encoding(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test writing with custom encoding."""
+        test_file = tmp_path / "latin1.txt"
+
+        node = FileWriteNode(
+            type="file-write",
+            id="encoding-write",
+            path=str(test_file),
+            content="Héllo Wörld",
+            encoding="latin-1",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert test_file.read_text(encoding="latin-1") == "Héllo Wörld"
+
+    @pytest.mark.asyncio
+    async def test_write_multiline_content(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test writing multiline content."""
+        test_file = tmp_path / "multiline.txt"
+        content = "Line 1\nLine 2\nLine 3"
+
+        node = FileWriteNode(
+            type="file-write",
+            id="multiline-write",
+            path=str(test_file),
+            content=content,
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert test_file.read_text() == content
+
+    @pytest.mark.asyncio
+    async def test_write_reports_size(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+    ) -> None:
+        """Test that file size is reported."""
+        test_file = tmp_path / "sized.txt"
+        content = "12345678901234567890"  # 20 bytes
+
+        node = FileWriteNode(
+            type="file-write",
+            id="size-test",
+            path=str(test_file),
+            content=content,
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["size"] == 20
+
+    @pytest.mark.asyncio
+    async def test_write_path_expansion_env_var(
+        self,
+        write_executor: FileWriteExecutor,
+        context: ExecutionContext,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test environment variable expansion in file path."""
+        monkeypatch.setenv("TEST_OUTPUT_DIR", str(tmp_path))
+
+        node = FileWriteNode(
+            type="file-write",
+            id="env-write",
+            path="$TEST_OUTPUT_DIR/env_output.txt",
+            content="env content",
+        )
+        result = await write_executor.execute(node, context)
+
+        assert result.status == "success"
+        assert (tmp_path / "env_output.txt").read_text() == "env content"
+

--- a/tests/test_nodes_http.py
+++ b/tests/test_nodes_http.py
@@ -1,0 +1,330 @@
+"""Tests for HTTP node executor."""
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from flowpilot.engine import ExecutionContext
+from flowpilot.engine.nodes import HttpExecutor
+from flowpilot.models import HttpNode
+
+
+@pytest.fixture
+def executor() -> HttpExecutor:
+    """Create an HTTP executor instance."""
+    return HttpExecutor()
+
+
+@pytest.fixture
+def context() -> ExecutionContext:
+    """Create an execution context."""
+    return ExecutionContext(workflow_name="test")
+
+
+class TestHttpExecutor:
+    """Tests for HttpExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_execute_get_request(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a simple GET request."""
+        httpx_mock.add_response(
+            url="https://api.example.com/data",
+            json={"status": "ok", "value": 42},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="get-test",
+            url="https://api.example.com/data",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["status_code"] == 200
+        assert result.data["body"]["status"] == "ok"
+        assert result.data["body"]["value"] == 42
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_execute_post_request_with_json_body(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a POST request with JSON body."""
+        httpx_mock.add_response(
+            url="https://api.example.com/create",
+            json={"id": 123, "created": True},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="post-test",
+            url="https://api.example.com/create",
+            method="POST",
+            body={"name": "test", "value": 100},
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["status_code"] == 200
+        assert result.data["body"]["id"] == 123
+        assert result.data["body"]["created"] is True
+
+    @pytest.mark.asyncio
+    async def test_execute_post_request_with_string_body(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a POST request with string body."""
+        httpx_mock.add_response(
+            url="https://api.example.com/raw",
+            text="OK",
+        )
+
+        node = HttpNode(
+            type="http",
+            id="post-string-test",
+            url="https://api.example.com/raw",
+            method="POST",
+            body="raw data content",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_execute_with_custom_headers(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test request with custom headers."""
+        httpx_mock.add_response(
+            url="https://api.example.com/auth",
+            json={"authenticated": True},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="headers-test",
+            url="https://api.example.com/auth",
+            method="GET",
+            headers={"Authorization": "Bearer token123", "X-Custom": "value"},
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        # Verify headers were sent
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.headers["Authorization"] == "Bearer token123"
+        assert request.headers["X-Custom"] == "value"
+
+    @pytest.mark.asyncio
+    async def test_execute_put_request(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a PUT request."""
+        httpx_mock.add_response(
+            url="https://api.example.com/update/1",
+            json={"updated": True},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="put-test",
+            url="https://api.example.com/update/1",
+            method="PUT",
+            body={"name": "updated"},
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.method == "PUT"
+
+    @pytest.mark.asyncio
+    async def test_execute_delete_request(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a DELETE request."""
+        httpx_mock.add_response(
+            url="https://api.example.com/delete/1",
+            json={"deleted": True},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="delete-test",
+            url="https://api.example.com/delete/1",
+            method="DELETE",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.method == "DELETE"
+
+    @pytest.mark.asyncio
+    async def test_execute_patch_request(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test executing a PATCH request."""
+        httpx_mock.add_response(
+            url="https://api.example.com/patch/1",
+            json={"patched": True},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="patch-test",
+            url="https://api.example.com/patch/1",
+            method="PATCH",
+            body={"field": "new_value"},
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.method == "PATCH"
+
+    @pytest.mark.asyncio
+    async def test_execute_http_error_response(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test handling HTTP error response (4xx/5xx)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/error",
+            status_code=404,
+            json={"error": "Not Found"},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="error-test",
+            url="https://api.example.com/error",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.data["status_code"] == 404
+        assert result.error_message is not None
+        assert "404" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_execute_server_error_response(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test handling server error (5xx)."""
+        httpx_mock.add_response(
+            url="https://api.example.com/server-error",
+            status_code=500,
+            json={"error": "Internal Server Error"},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="server-error-test",
+            url="https://api.example.com/server-error",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.data["status_code"] == 500
+        assert result.error_message is not None
+        assert "500" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_execute_non_json_response(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test handling non-JSON response."""
+        httpx_mock.add_response(
+            url="https://api.example.com/html",
+            text="<html><body>Hello</body></html>",
+            headers={"Content-Type": "text/html"},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="html-test",
+            url="https://api.example.com/html",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert result.data["body"]["text"] == "<html><body>Hello</body></html>"
+        assert "<html>" in result.output
+
+    @pytest.mark.asyncio
+    async def test_execute_timeout(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test request timeout handling."""
+        import httpx
+
+        httpx_mock.add_exception(httpx.TimeoutException("Connection timed out"))
+
+        node = HttpNode(
+            type="http",
+            id="timeout-test",
+            url="https://api.example.com/slow",
+            method="GET",
+            timeout=1,
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "timed out" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_connection_error(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test connection error handling."""
+        import httpx
+
+        httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
+
+        node = HttpNode(
+            type="http",
+            id="connection-test",
+            url="https://api.example.com/unreachable",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "connection" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_response_headers_captured(
+        self, executor: HttpExecutor, context: ExecutionContext, httpx_mock: HTTPXMock
+    ) -> None:
+        """Test that response headers are captured."""
+        httpx_mock.add_response(
+            url="https://api.example.com/headers",
+            json={"data": "value"},
+            headers={"X-Custom-Header": "custom-value", "X-Rate-Limit": "100"},
+        )
+
+        node = HttpNode(
+            type="http",
+            id="response-headers-test",
+            url="https://api.example.com/headers",
+            method="GET",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "headers" in result.data
+        assert result.data["headers"]["x-custom-header"] == "custom-value"
+        assert result.data["headers"]["x-rate-limit"] == "100"
+

--- a/tests/test_nodes_shell.py
+++ b/tests/test_nodes_shell.py
@@ -1,0 +1,183 @@
+"""Tests for shell node executor."""
+
+import os
+import sys
+
+import pytest
+
+from flowpilot.engine import ExecutionContext
+from flowpilot.engine.nodes import ShellExecutor
+from flowpilot.models import ShellNode
+
+
+@pytest.fixture
+def executor() -> ShellExecutor:
+    """Create a shell executor instance."""
+    return ShellExecutor()
+
+
+@pytest.fixture
+def context() -> ExecutionContext:
+    """Create an execution context."""
+    return ExecutionContext(workflow_name="test")
+
+
+class TestShellExecutor:
+    """Tests for ShellExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_execute_simple_command(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test executing a simple echo command."""
+        node = ShellNode(type="shell", id="echo-test", command="echo hello")
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "hello" in result.stdout
+        assert result.output == "hello"
+        assert result.data["exit_code"] == 0
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_stderr(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command that writes to stderr."""
+        node = ShellNode(
+            type="shell",
+            id="stderr-test",
+            command="echo error >&2",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "error" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_execute_failing_command(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command with non-zero exit code."""
+        node = ShellNode(type="shell", id="fail-test", command="exit 1")
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.data["exit_code"] == 1
+        assert result.error_message is not None
+        assert "exit" in result.error_message.lower() or "code" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_with_environment(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command with custom environment variables."""
+        node = ShellNode(
+            type="shell",
+            id="env-test",
+            command="echo $MY_VAR",
+            env={"MY_VAR": "custom_value"},
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "custom_value" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_execute_with_working_directory(
+        self, executor: ShellExecutor, context: ExecutionContext, tmp_path: str
+    ) -> None:
+        """Test command with working directory."""
+        node = ShellNode(
+            type="shell",
+            id="cwd-test",
+            command="pwd",
+            working_dir=str(tmp_path),
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert str(tmp_path) in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_execute_timeout(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command timeout."""
+        node = ShellNode(
+            type="shell",
+            id="timeout-test",
+            command="sleep 10",
+            timeout=1,
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+        assert "timed out" in result.error_message.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_working_directory(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command with non-existent working directory."""
+        node = ShellNode(
+            type="shell",
+            id="invalid-cwd-test",
+            command="echo test",
+            working_dir="/nonexistent/path/12345",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "error"
+        assert result.error_message is not None
+
+    @pytest.mark.asyncio
+    async def test_execute_multiline_output(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command with multiline output."""
+        node = ShellNode(
+            type="shell",
+            id="multiline-test",
+            command="echo 'line1\nline2\nline3'",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "line1" in result.stdout
+        assert "line2" in result.stdout
+        assert "line3" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_execute_path_expansion(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test ~ expansion in working directory."""
+        node = ShellNode(
+            type="shell",
+            id="path-test",
+            command="pwd",
+            working_dir="~",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        # Should expand to home directory, not literal ~
+        assert "~" not in result.stdout or os.path.expanduser("~") in result.stdout
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test")
+    async def test_execute_pipe_command(
+        self, executor: ShellExecutor, context: ExecutionContext
+    ) -> None:
+        """Test command with pipes."""
+        node = ShellNode(
+            type="shell",
+            id="pipe-test",
+            command="echo 'hello world' | tr 'a-z' 'A-Z'",
+        )
+        result = await executor.execute(node, context)
+
+        assert result.status == "success"
+        assert "HELLO WORLD" in result.stdout


### PR DESCRIPTION
## Summary

- Implements 5 core node executors for the FlowPilot workflow engine:
  - **ShellExecutor**: Execute shell commands with timeout, env vars, and working directory
  - **HttpExecutor**: HTTP requests (GET/POST/PUT/DELETE/PATCH) with JSON body and headers
  - **FileReadExecutor**: Read files with encoding support and ~ / $ENV expansion
  - **FileWriteExecutor**: Write/append files with auto directory creation
  - **ConditionExecutor**: Safe Python expression evaluation for workflow branching

- All executors include proper error handling, duration tracking, and timeout support
- Adds `pytest-httpx` for HTTP mocking in tests
- Adds `populate_by_name=True` to Pydantic model config for flexible field access

## Test plan

- [x] 67 new tests covering all node executor types
- [x] All 218 tests passing
- [x] Ruff linting passes
- [x] Mypy type checking passes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)