### PR TITLE
feat: Phase 1.5 - CLI Foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,11 @@ select = [
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)
+    "B008",   # function call in default argument (required by Typer)
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"src/flowpilot/cli/commands/*.py" = ["B904"]  # typer.Exit doesn't use exception chaining
 
 [tool.ruff.lint.isort]
 known-first-party = ["flowpilot"]

--- a/src/flowpilot/cli/__init__.py
+++ b/src/flowpilot/cli/__init__.py
@@ -1,14 +1,29 @@
 """FlowPilot CLI interface."""
 
+from pathlib import Path
+
 import typer
 from rich.console import Console
 
+# CLI App
 app = typer.Typer(
     name="flowpilot",
     help="Workflow automation for macOS with Claude Code integration.",
     no_args_is_help=True,
 )
+
+# Console for rich output
 console = Console()
+
+# Default paths
+FLOWPILOT_DIR = Path.home() / ".flowpilot"
+WORKFLOWS_DIR = FLOWPILOT_DIR / "workflows"
+LOGS_DIR = FLOWPILOT_DIR / "logs"
+CONFIG_FILE = FLOWPILOT_DIR / "config.yaml"
+DB_FILE = FLOWPILOT_DIR / "flowpilot.db"
+
+# Import commands to register them
+from flowpilot.cli.commands import init, list_cmd, run, validate  # noqa: E402, F401
 
 
 @app.command()
@@ -17,30 +32,6 @@ def version() -> None:
     from flowpilot import __version__
 
     console.print(f"FlowPilot v{__version__}")
-
-
-@app.command()
-def init() -> None:
-    """Initialize FlowPilot directory structure."""
-    console.print("[yellow]init command not yet implemented[/]")
-
-
-@app.command()
-def run(name: str = typer.Argument(..., help="Workflow name to run")) -> None:
-    """Execute a workflow."""
-    console.print(f"[yellow]run command not yet implemented for: {name}[/]")
-
-
-@app.command("list")
-def list_workflows() -> None:
-    """List available workflows."""
-    console.print("[yellow]list command not yet implemented[/]")
-
-
-@app.command()
-def validate(name: str = typer.Argument(..., help="Workflow name to validate")) -> None:
-    """Validate a workflow YAML file."""
-    console.print(f"[yellow]validate command not yet implemented for: {name}[/]")
 
 
 if __name__ == "__main__":

--- a/src/flowpilot/cli/commands/__init__.py
+++ b/src/flowpilot/cli/commands/__init__.py
@@ -1,0 +1,12 @@
+"""CLI commands for FlowPilot."""
+
+# Import command modules to register them with the app
+# These imports have side effects (register commands via @app.command())
+from flowpilot.cli.commands import (
+    init,
+    list_cmd,
+    run,
+    validate,
+)
+
+__all__ = ["init", "list_cmd", "run", "validate"]

--- a/src/flowpilot/cli/commands/init.py
+++ b/src/flowpilot/cli/commands/init.py
@@ -1,0 +1,85 @@
+"""Init command for FlowPilot CLI."""
+
+import typer
+import yaml
+
+from flowpilot.cli import (
+    CONFIG_FILE,
+    FLOWPILOT_DIR,
+    LOGS_DIR,
+    WORKFLOWS_DIR,
+    app,
+    console,
+)
+
+EXAMPLE_WORKFLOW = """\
+name: hello-world
+description: Example workflow to get started with FlowPilot
+
+triggers:
+  - type: manual
+
+nodes:
+  - id: greet
+    type: shell
+    command: echo "Hello from FlowPilot!"
+
+  - id: show-date
+    type: shell
+    command: date
+    depends_on:
+      - greet
+"""
+
+
+@app.command()
+def init(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite existing configuration",
+    ),
+) -> None:
+    """Initialize FlowPilot directory structure.
+
+    Creates the ~/.flowpilot directory with:
+    - workflows/ directory for workflow YAML files
+    - logs/ directory for execution logs
+    - config.yaml with default settings
+    - An example hello-world workflow
+    """
+    if FLOWPILOT_DIR.exists() and not force:
+        console.print(f"[yellow]FlowPilot already initialized at {FLOWPILOT_DIR}[/]")
+        console.print("Use [cyan]--force[/] to reinitialize")
+        raise typer.Exit(1)
+
+    # Create directories
+    WORKFLOWS_DIR.mkdir(parents=True, exist_ok=True)
+    LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Create default config
+    default_config = {
+        "server": {
+            "host": "127.0.0.1",
+            "port": 8080,
+        },
+        "claude": {
+            "default_model": "sonnet",
+        },
+        "execution": {
+            "default_timeout": 300,
+            "max_parallel_nodes": 10,
+        },
+    }
+    CONFIG_FILE.write_text(yaml.dump(default_config, default_flow_style=False, sort_keys=False))
+
+    # Create example workflow
+    example_path = WORKFLOWS_DIR / "hello-world.yaml"
+    example_path.write_text(EXAMPLE_WORKFLOW)
+
+    console.print(f"[green]✓[/] Initialized FlowPilot at {FLOWPILOT_DIR}")
+    console.print(f"[green]✓[/] Created config file: {CONFIG_FILE}")
+    console.print("[green]✓[/] Created example workflow: hello-world")
+    console.print()
+    console.print("Run [cyan]flowpilot run hello-world[/] to test your setup")

--- a/src/flowpilot/cli/commands/list_cmd.py
+++ b/src/flowpilot/cli/commands/list_cmd.py
@@ -1,0 +1,99 @@
+"""List command for FlowPilot CLI."""
+
+from typing import Any
+
+import typer
+from rich.table import Table
+
+from flowpilot.cli import WORKFLOWS_DIR, app, console
+from flowpilot.engine.parser import WorkflowParser
+
+
+@app.command("list")
+def list_workflows(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output as JSON",
+    ),
+) -> None:
+    """List available workflows.
+
+    Shows all workflow YAML files in the ~/.flowpilot/workflows directory.
+    """
+    if not WORKFLOWS_DIR.exists():
+        if json_output:
+            console.print_json(data={"error": "Workflows directory not found", "workflows": []})
+        else:
+            console.print("[yellow]No workflows directory found.[/]")
+            console.print("Run [cyan]flowpilot init[/] to create it.")
+        raise typer.Exit(1)
+
+    workflows: list[dict[str, Any]] = []
+    parser = WorkflowParser()
+
+    # Find all YAML files
+    yaml_files = list(WORKFLOWS_DIR.glob("*.yaml")) + list(WORKFLOWS_DIR.glob("*.yml"))
+
+    for path in sorted(yaml_files):
+        try:
+            wf = parser.parse_file(path)
+            workflows.append(
+                {
+                    "name": wf.name,
+                    "description": wf.description or "",
+                    "triggers": [t.type for t in wf.triggers],
+                    "nodes": len(wf.nodes),
+                    "inputs": len(wf.inputs),
+                    "path": str(path),
+                }
+            )
+        except Exception as e:
+            workflows.append(
+                {
+                    "name": path.stem,
+                    "error": str(e),
+                    "path": str(path),
+                }
+            )
+
+    if json_output:
+        console.print_json(data={"workflows": workflows})
+        return
+
+    if not workflows:
+        console.print("[yellow]No workflows found.[/]")
+        console.print(f"Create workflows in: [cyan]{WORKFLOWS_DIR}[/]")
+        return
+
+    # Build table
+    table = Table(title="Workflows")
+    table.add_column("Name", style="cyan")
+    table.add_column("Description")
+    table.add_column("Triggers")
+    table.add_column("Nodes", justify="right")
+
+    for wf_info in workflows:
+        if "error" in wf_info:
+            table.add_row(
+                wf_info["name"],
+                f"[red]Error: {wf_info['error'][:40]}...[/]"
+                if len(wf_info.get("error", "")) > 40
+                else f"[red]Error: {wf_info.get('error', '')}[/]",
+                "",
+                "",
+            )
+        else:
+            triggers = ", ".join(wf_info["triggers"]) if wf_info["triggers"] else "[dim]none[/]"
+            table.add_row(
+                wf_info["name"],
+                wf_info["description"][:50] + "..."
+                if len(wf_info["description"]) > 50
+                else wf_info["description"],
+                triggers,
+                str(wf_info["nodes"]),
+            )
+
+    console.print(table)
+    console.print()
+    console.print(f"[dim]Workflows directory: {WORKFLOWS_DIR}[/]")

--- a/src/flowpilot/cli/commands/run.py
+++ b/src/flowpilot/cli/commands/run.py
@@ -1,0 +1,184 @@
+"""Run command for FlowPilot CLI."""
+
+import asyncio
+from typing import Any
+
+import typer
+from pydantic import ValidationError
+from rich.table import Table
+
+# Import node executors to register them with the registry
+import flowpilot.engine.nodes  # noqa: F401
+from flowpilot.cli import app, console
+from flowpilot.cli.utils import resolve_workflow_path
+from flowpilot.engine.context import ExecutionContext
+from flowpilot.engine.parser import WorkflowParser
+from flowpilot.engine.runner import WorkflowRunner
+
+
+@app.command()
+def run(
+    name: str = typer.Argument(..., help="Workflow name or path to YAML file"),
+    inputs: list[str] = typer.Option(
+        [],
+        "--input",
+        "-i",
+        help="Input as key=value (can be used multiple times)",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Output results as JSON",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show detailed output including node outputs",
+    ),
+) -> None:
+    """Execute a workflow.
+
+    Runs all nodes in the workflow in dependency order and displays results.
+    Use --input to pass runtime inputs to the workflow.
+
+    Examples:
+        flowpilot run my-workflow
+        flowpilot run my-workflow --input name=value --input count=10
+        flowpilot run my-workflow --json
+    """
+    path = resolve_workflow_path(name)
+
+    # Parse workflow
+    try:
+        parser = WorkflowParser()
+        workflow = parser.parse_file(path)
+    except ValidationError as e:
+        console.print(f"[red]✗[/] Invalid workflow [cyan]{path.name}[/]:")
+        for error in e.errors():
+            loc = " → ".join(str(loc_part) for loc_part in error["loc"])
+            console.print(f"  [red]•[/] [yellow]{loc}[/]: {error['msg']}")
+        raise typer.Exit(1)
+    except Exception as e:
+        console.print(f"[red]✗[/] Error loading workflow: {e}")
+        raise typer.Exit(1)
+
+    # Parse inputs
+    input_dict: dict[str, str] = {}
+    for inp in inputs:
+        if "=" not in inp:
+            console.print(f"[red]Error:[/] Invalid input format: {inp}")
+            console.print("Use [cyan]--input key=value[/]")
+            raise typer.Exit(1)
+        key, value = inp.split("=", 1)
+        input_dict[key] = value
+
+    if not json_output:
+        console.print(f"[cyan]▶[/] Running workflow: [bold]{workflow.name}[/]")
+        if input_dict:
+            console.print(f"  [dim]Inputs: {input_dict}[/]")
+        console.print()
+
+    # Execute workflow
+    try:
+        runner = WorkflowRunner()
+        context = asyncio.run(runner.run(workflow, input_dict))
+    except Exception as e:
+        if json_output:
+            console.print_json(data={"error": str(e), "status": "failed"})
+        else:
+            console.print(f"[red]✗[/] Execution failed: {e}")
+        raise typer.Exit(1)
+
+    # Display results
+    if json_output:
+        console.print_json(data=_context_to_dict(context))
+    else:
+        _display_results(context, verbose)
+
+    # Exit code based on any errors
+    has_errors = any(r.status == "error" for r in context.nodes.values())
+    if has_errors:
+        raise typer.Exit(1)
+
+
+def _context_to_dict(context: ExecutionContext) -> dict[str, Any]:
+    """Convert execution context to dictionary for JSON output."""
+    return {
+        "execution_id": context.execution_id,
+        "workflow_name": context.workflow_name,
+        "inputs": context.inputs,
+        "nodes": {
+            node_id: {
+                "status": result.status,
+                "output": result.output,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "data": result.data,
+                "error_message": result.error_message,
+                "duration_ms": result.duration_ms,
+                "started_at": result.started_at.isoformat() if result.started_at else None,
+                "finished_at": result.finished_at.isoformat() if result.finished_at else None,
+            }
+            for node_id, result in context.nodes.items()
+        },
+    }
+
+
+def _display_results(context: ExecutionContext, verbose: bool) -> None:
+    """Display execution results in a formatted table."""
+    # Count results by status
+    success_count = sum(1 for r in context.nodes.values() if r.status == "success")
+    error_count = sum(1 for r in context.nodes.values() if r.status == "error")
+    skipped_count = sum(1 for r in context.nodes.values() if r.status == "skipped")
+
+    # Build table
+    table = Table(title=f"Execution: {context.execution_id[:8]}")
+    table.add_column("Node", style="cyan")
+    table.add_column("Status")
+    table.add_column("Duration", justify="right")
+    if verbose:
+        table.add_column("Output")
+
+    for node_id, result in context.nodes.items():
+        status_display = {
+            "success": "[green]✓ success[/]",
+            "error": "[red]✗ error[/]",
+            "skipped": "[yellow]○ skipped[/]",
+            "pending": "[dim]• pending[/]",
+            "running": "[blue]◉ running[/]",
+        }.get(result.status, f"? {result.status}")
+
+        duration = f"{result.duration_ms}ms" if result.duration_ms else "-"
+
+        if verbose:
+            output = ""
+            if result.error_message:
+                output = f"[red]{result.error_message[:60]}[/]"
+            elif result.output:
+                output = result.output[:60]
+                if len(result.output) > 60:
+                    output += "..."
+            table.add_row(node_id, status_display, duration, output)
+        else:
+            table.add_row(node_id, status_display, duration)
+
+    console.print(table)
+
+    # Summary
+    console.print()
+    total = len(context.nodes)
+    summary_parts = []
+    if success_count:
+        summary_parts.append(f"[green]{success_count} passed[/]")
+    if error_count:
+        summary_parts.append(f"[red]{error_count} failed[/]")
+    if skipped_count:
+        summary_parts.append(f"[yellow]{skipped_count} skipped[/]")
+
+    console.print(f"Total: {total} nodes | {' | '.join(summary_parts)}")
+
+    # Show errors in detail if any
+    if error_count and not verbose:
+        console.print()
+        console.print("[dim]Use --verbose to see error details[/]")

--- a/src/flowpilot/cli/commands/validate.py
+++ b/src/flowpilot/cli/commands/validate.py
@@ -1,0 +1,61 @@
+"""Validate command for FlowPilot CLI."""
+
+import typer
+from pydantic import ValidationError
+
+from flowpilot.cli import app, console
+from flowpilot.cli.utils import resolve_workflow_path
+from flowpilot.engine.parser import WorkflowParser
+
+
+@app.command()
+def validate(
+    name: str = typer.Argument(..., help="Workflow name or path to YAML file"),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show detailed workflow information",
+    ),
+) -> None:
+    """Validate a workflow YAML file.
+
+    Checks that the workflow:
+    - Has valid YAML syntax
+    - Conforms to the FlowPilot schema
+    - Has valid node references (depends_on, then/else, etc.)
+    """
+    path = resolve_workflow_path(name)
+
+    try:
+        parser = WorkflowParser()
+        workflow = parser.parse_file(path)
+
+        console.print(f"[green]✓[/] Workflow [cyan]{workflow.name}[/] is valid")
+
+        if verbose:
+            console.print()
+            console.print(f"  [dim]Description:[/] {workflow.description or '(none)'}")
+            console.print(f"  [dim]Triggers:[/] {len(workflow.triggers)}")
+            console.print(f"  [dim]Nodes:[/] {len(workflow.nodes)}")
+            console.print(f"  [dim]Inputs:[/] {len(workflow.inputs)}")
+
+            if workflow.nodes:
+                console.print()
+                console.print("  [dim]Node IDs:[/]")
+                for node in workflow.nodes:
+                    node_type = getattr(node, "type", "unknown")
+                    console.print(f"    - {node.id} [dim]({node_type})[/]")
+
+    except ValidationError as e:
+        console.print(f"[red]✗[/] Validation failed for [cyan]{path.name}[/]:")
+        console.print()
+        for error in e.errors():
+            loc = " → ".join(str(loc_part) for loc_part in error["loc"])
+            msg = error["msg"]
+            console.print(f"  [red]•[/] [yellow]{loc}[/]: {msg}")
+        raise typer.Exit(1)
+
+    except Exception as e:
+        console.print(f"[red]✗[/] Error parsing workflow: {e}")
+        raise typer.Exit(1)

--- a/src/flowpilot/cli/utils.py
+++ b/src/flowpilot/cli/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for FlowPilot CLI."""
+
+from pathlib import Path
+
+import typer
+
+from flowpilot.cli import WORKFLOWS_DIR, console
+
+
+def resolve_workflow_path(name: str) -> Path:
+    """Resolve workflow name to file path.
+
+    Args:
+        name: Workflow name or path to YAML file.
+
+    Returns:
+        Path to the workflow file.
+
+    Raises:
+        typer.Exit: If workflow file not found.
+    """
+    # If it's already a path to a file
+    if name.endswith(".yaml") or name.endswith(".yml"):
+        path = Path(name)
+        if path.exists():
+            return path
+        console.print(f"[red]Error:[/] Workflow file not found: {path}")
+        raise typer.Exit(1)
+
+    # Look in workflows directory
+    for ext in [".yaml", ".yml"]:
+        path = WORKFLOWS_DIR / f"{name}{ext}"
+        if path.exists():
+            return path
+
+    # Not found
+    console.print(f"[red]Error:[/] Workflow not found: {name}")
+    console.print(f"Looked in: {WORKFLOWS_DIR}")
+    raise typer.Exit(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,48 +1,278 @@
 """Tests for FlowPilot CLI."""
 
+import json
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
 
 from flowpilot import __version__
 from flowpilot.cli import app
 
-runner = CliRunner()
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
 
 
-def test_version_command() -> None:
-    """Test version command shows version."""
-    result = runner.invoke(app, ["version"])
-    assert result.exit_code == 0
-    assert __version__ in result.stdout
+@pytest.fixture
+def temp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a temporary home directory and patch paths."""
+    flowpilot_dir = tmp_path / ".flowpilot"
+    workflows_dir = flowpilot_dir / "workflows"
+    logs_dir = flowpilot_dir / "logs"
+    config_file = flowpilot_dir / "config.yaml"
+    db_file = flowpilot_dir / "flowpilot.db"
+
+    # Patch the CLI constants to use temp directory
+    monkeypatch.setattr("flowpilot.cli.FLOWPILOT_DIR", flowpilot_dir)
+    monkeypatch.setattr("flowpilot.cli.WORKFLOWS_DIR", workflows_dir)
+    monkeypatch.setattr("flowpilot.cli.LOGS_DIR", logs_dir)
+    monkeypatch.setattr("flowpilot.cli.CONFIG_FILE", config_file)
+    monkeypatch.setattr("flowpilot.cli.DB_FILE", db_file)
+
+    # Also patch in the commands modules
+    monkeypatch.setattr("flowpilot.cli.commands.init.FLOWPILOT_DIR", flowpilot_dir)
+    monkeypatch.setattr("flowpilot.cli.commands.init.WORKFLOWS_DIR", workflows_dir)
+    monkeypatch.setattr("flowpilot.cli.commands.init.LOGS_DIR", logs_dir)
+    monkeypatch.setattr("flowpilot.cli.commands.init.CONFIG_FILE", config_file)
+    monkeypatch.setattr("flowpilot.cli.commands.list_cmd.WORKFLOWS_DIR", workflows_dir)
+    monkeypatch.setattr("flowpilot.cli.utils.WORKFLOWS_DIR", workflows_dir)
+
+    return tmp_path
 
 
-def test_help_shows_commands() -> None:
-    """Test help shows available commands."""
-    result = runner.invoke(app, ["--help"])
-    assert result.exit_code == 0
-    assert "init" in result.stdout
-    assert "run" in result.stdout
-    assert "list" in result.stdout
-    assert "validate" in result.stdout
+class TestHelp:
+    """Tests for help output."""
+
+    def test_help_shows_commands(self, runner: CliRunner) -> None:
+        """Test help shows available commands."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "init" in result.output
+        assert "run" in result.output
+        assert "list" in result.output
+        assert "validate" in result.output
 
 
-def test_init_command_exists() -> None:
-    """Test init command is available."""
-    result = runner.invoke(app, ["init"])
-    assert result.exit_code == 0
-    assert "not yet implemented" in result.stdout
+class TestVersion:
+    """Tests for version command."""
+
+    def test_version(self, runner: CliRunner) -> None:
+        """Test version command shows version."""
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
 
 
-def test_run_requires_name() -> None:
-    """Test run command requires workflow name."""
-    result = runner.invoke(app, ["run"])
-    assert result.exit_code != 0
-    # Typer outputs errors to stderr, which is captured in output
-    assert "Missing argument" in result.output or result.exit_code == 2
+class TestInit:
+    """Tests for init command."""
+
+    def test_init_creates_directories(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test init creates directory structure."""
+        result = runner.invoke(app, ["init"])
+
+        assert result.exit_code == 0
+        assert "Initialized FlowPilot" in result.output
+
+        flowpilot_dir = temp_home / ".flowpilot"
+        assert flowpilot_dir.exists()
+        assert (flowpilot_dir / "workflows").exists()
+        assert (flowpilot_dir / "logs").exists()
+        assert (flowpilot_dir / "config.yaml").exists()
+
+    def test_init_creates_example_workflow(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test init creates example workflow."""
+        result = runner.invoke(app, ["init"])
+
+        assert result.exit_code == 0
+        example = temp_home / ".flowpilot" / "workflows" / "hello-world.yaml"
+        assert example.exists()
+        assert "hello-world" in example.read_text()
+
+    def test_init_refuses_without_force(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test init refuses to overwrite without --force."""
+        # First init
+        runner.invoke(app, ["init"])
+
+        # Second init without force
+        result = runner.invoke(app, ["init"])
+        assert result.exit_code == 1
+        assert "already initialized" in result.output
+
+    def test_init_with_force(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test init with --force overwrites."""
+        # First init
+        runner.invoke(app, ["init"])
+
+        # Second init with force
+        result = runner.invoke(app, ["init", "--force"])
+        assert result.exit_code == 0
+        assert "Initialized FlowPilot" in result.output
 
 
-def test_validate_requires_name() -> None:
-    """Test validate command requires workflow name."""
-    result = runner.invoke(app, ["validate"])
-    assert result.exit_code != 0
-    # Typer outputs errors to stderr, which is captured in output
-    assert "Missing argument" in result.output or result.exit_code == 2
+class TestValidate:
+    """Tests for validate command."""
+
+    def test_validate_requires_name(self, runner: CliRunner) -> None:
+        """Test validate command requires workflow name."""
+        result = runner.invoke(app, ["validate"])
+        assert result.exit_code != 0
+
+    def test_validate_valid_workflow(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test validate with valid workflow."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["validate", "hello-world"])
+        assert result.exit_code == 0
+        assert "is valid" in result.output
+
+    def test_validate_verbose(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test validate with --verbose shows details."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["validate", "hello-world", "--verbose"])
+        assert result.exit_code == 0
+        assert "Nodes:" in result.output
+        assert "Triggers:" in result.output
+
+    def test_validate_not_found(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test validate with non-existent workflow."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["validate", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_validate_invalid_workflow(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test validate with invalid workflow."""
+        runner.invoke(app, ["init"])
+
+        # Create invalid workflow
+        invalid = temp_home / ".flowpilot" / "workflows" / "invalid.yaml"
+        invalid.write_text("name: invalid\n# missing nodes\n")
+
+        result = runner.invoke(app, ["validate", "invalid"])
+        assert result.exit_code == 1
+        assert "Validation failed" in result.output or "Error" in result.output
+
+
+class TestRun:
+    """Tests for run command."""
+
+    def test_run_requires_name(self, runner: CliRunner) -> None:
+        """Test run command requires workflow name."""
+        result = runner.invoke(app, ["run"])
+        assert result.exit_code != 0
+
+    def test_run_workflow(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test running a workflow."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["run", "hello-world"])
+        assert result.exit_code == 0
+        assert "Running workflow" in result.output
+        assert "hello-world" in result.output
+
+    def test_run_with_json_output(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test run with --json outputs JSON."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["run", "hello-world", "--json"])
+        assert result.exit_code == 0
+
+        # Should be valid JSON
+        data = json.loads(result.output)
+        assert "execution_id" in data
+        assert "nodes" in data
+
+    def test_run_not_found(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test run with non-existent workflow."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["run", "nonexistent"])
+        assert result.exit_code == 1
+        assert "not found" in result.output
+
+    def test_run_with_verbose(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test run with --verbose shows output."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["run", "hello-world", "--verbose"])
+        assert result.exit_code == 0
+
+    def test_run_with_inputs(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test run with --input passes inputs."""
+        runner.invoke(app, ["init"])
+
+        # Just verify the inputs are parsed and passed - use simple workflow
+        result = runner.invoke(app, ["run", "hello-world", "--input", "mykey=myvalue"])
+        # Workflow runs successfully even with extra inputs
+        assert result.exit_code == 0
+        assert "Inputs:" in result.output or "hello-world" in result.output
+
+    def test_run_invalid_input_format(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test run with invalid input format."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["run", "hello-world", "--input", "invalid-no-equals"])
+        assert result.exit_code == 1
+        assert "Invalid input format" in result.output
+
+
+class TestList:
+    """Tests for list command."""
+
+    def test_list_no_init(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test list without init shows error."""
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 1
+        assert "not found" in result.output or "init" in result.output
+
+    def test_list_workflows(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test list shows workflows."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "hello-world" in result.output
+        assert "Workflows" in result.output
+
+    def test_list_json(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test list with --json outputs JSON."""
+        runner.invoke(app, ["init"])
+
+        result = runner.invoke(app, ["list", "--json"])
+        assert result.exit_code == 0
+
+        data = json.loads(result.output)
+        assert "workflows" in data
+        assert len(data["workflows"]) >= 1
+        assert data["workflows"][0]["name"] == "hello-world"
+
+    def test_list_empty(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test list with no workflows."""
+        runner.invoke(app, ["init"])
+
+        # Remove example workflow
+        example = temp_home / ".flowpilot" / "workflows" / "hello-world.yaml"
+        example.unlink()
+
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "No workflows found" in result.output
+
+    def test_list_invalid_workflow(self, runner: CliRunner, temp_home: Path) -> None:
+        """Test list shows error for invalid workflow."""
+        runner.invoke(app, ["init"])
+
+        # Create invalid workflow
+        invalid = temp_home / ".flowpilot" / "workflows" / "broken.yaml"
+        invalid.write_text("this: is: not: valid: yaml: [")
+
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        # Should show the valid workflow and error for invalid
+        assert "hello-world" in result.output
+        assert "Error" in result.output or "broken" in result.output


### PR DESCRIPTION
## Summary

Implements the core FlowPilot CLI commands using Typer and Rich:

- **`flowpilot init`**: Initialize ~/.flowpilot directory with workflows/, logs/, config.yaml, and example hello-world workflow
- **`flowpilot validate <name>`**: Validate workflow YAML syntax and schema with detailed error messages
- **`flowpilot run <name>`**: Execute workflow with colored status table output
- **`flowpilot list`**: List available workflows in a formatted table
- **`flowpilot version`**: Show FlowPilot version

### Features
- `--input key=value` flag for runtime inputs
- `--json` flag for JSON output (scripting friendly)
- `--verbose` flag for detailed output
- `--force` flag for init to overwrite existing config
- Colored output with status indicators (✓/✗/○)
- Clear error messages with validation details

### Files
- `src/flowpilot/cli/__init__.py`: Entry point, app, constants
- `src/flowpilot/cli/commands/`: Command modules (init, validate, run, list_cmd)
- `src/flowpilot/cli/utils.py`: Shared utilities

## Test plan

- [x] 23 CLI tests covering all commands
- [x] All 236 tests passing
- [x] Ruff linting passes
- [x] Ruff formatting passes
- [x] Mypy type checking passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)