### PR TITLE
feat: Phase 2.3 - Webhook Triggers

### DIFF
--- a/src/flowpilot/api/__init__.py
+++ b/src/flowpilot/api/__init__.py
@@ -1,1 +1,23 @@
-"""FlowPilot API server."""
+"""FlowPilot API server.
+
+This module provides the FastAPI-based API server for FlowPilot,
+including webhook endpoints for triggering workflows via HTTP.
+"""
+
+from .webhooks import (
+    get_webhook,
+    get_webhooks,
+    register_webhook,
+    router,
+    set_global_webhook_runner,
+    unregister_webhook,
+)
+
+__all__ = [
+    "get_webhook",
+    "get_webhooks",
+    "register_webhook",
+    "router",
+    "set_global_webhook_runner",
+    "unregister_webhook",
+]

--- a/src/flowpilot/api/webhooks.py
+++ b/src/flowpilot/api/webhooks.py
@@ -1,0 +1,287 @@
+"""Webhook endpoint handling for FlowPilot workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, BackgroundTasks, Header, HTTPException, Request
+
+if TYPE_CHECKING:
+    from flowpilot.engine.runner import WorkflowRunner
+
+logger = logging.getLogger(__name__)
+
+# Router for webhook endpoints
+router = APIRouter(prefix="/hooks", tags=["webhooks"])
+
+# Registry of active webhooks: path -> {workflow_name, workflow_path, secret}
+_webhooks: dict[str, dict[str, Any]] = {}
+
+# Global reference to runner for webhook execution
+_global_runner: WorkflowRunner | None = None
+
+
+def set_global_webhook_runner(runner: WorkflowRunner | None) -> None:
+    """Set the global workflow runner for webhook execution.
+
+    Args:
+        runner: WorkflowRunner instance to use for executing workflows.
+    """
+    global _global_runner
+    _global_runner = runner
+
+
+def register_webhook(
+    path: str,
+    workflow_name: str,
+    workflow_path: str,
+    secret: str | None = None,
+) -> str:
+    """Register a webhook endpoint.
+
+    Args:
+        path: Webhook path (e.g., /github-push).
+        workflow_name: Name of the workflow to trigger.
+        workflow_path: Path to the workflow file.
+        secret: Optional secret for authentication.
+
+    Returns:
+        The registered webhook path.
+    """
+    # Normalize path
+    if not path.startswith("/"):
+        path = "/" + path
+
+    _webhooks[path] = {
+        "workflow_name": workflow_name,
+        "workflow_path": workflow_path,
+        "secret": secret,
+    }
+
+    logger.info(f"Registered webhook for workflow '{workflow_name}' at path: {path}")
+    return path
+
+
+def unregister_webhook(workflow_name: str) -> bool:
+    """Remove webhook for a workflow.
+
+    Args:
+        workflow_name: Name of the workflow to unregister.
+
+    Returns:
+        True if webhook was removed, False if not found.
+    """
+    to_remove = [
+        path for path, config in _webhooks.items() if config["workflow_name"] == workflow_name
+    ]
+
+    if not to_remove:
+        return False
+
+    for path in to_remove:
+        del _webhooks[path]
+        logger.info(f"Unregistered webhook at path: {path}")
+
+    return True
+
+
+def get_webhooks() -> list[dict[str, Any]]:
+    """List all registered webhooks.
+
+    Returns:
+        List of webhook information dictionaries.
+    """
+    return [
+        {
+            "path": path,
+            "workflow_name": config["workflow_name"],
+            "has_secret": config["secret"] is not None,
+        }
+        for path, config in _webhooks.items()
+    ]
+
+
+def get_webhook(workflow_name: str) -> dict[str, Any] | None:
+    """Get webhook info for a specific workflow.
+
+    Args:
+        workflow_name: Name of the workflow.
+
+    Returns:
+        Webhook information or None if not found.
+    """
+    for path, config in _webhooks.items():
+        if config["workflow_name"] == workflow_name:
+            return {
+                "path": path,
+                "workflow_name": config["workflow_name"],
+                "has_secret": config["secret"] is not None,
+            }
+    return None
+
+
+def _verify_secret(
+    config: dict[str, Any],
+    body: bytes,
+    x_webhook_secret: str | None,
+    x_signature: str | None,
+) -> bool:
+    """Verify webhook secret/signature.
+
+    Args:
+        config: Webhook configuration with secret.
+        body: Request body bytes.
+        x_webhook_secret: Simple secret header value.
+        x_signature: HMAC signature header value.
+
+    Returns:
+        True if verification passes, False otherwise.
+
+    Raises:
+        HTTPException: If authentication is required but missing/invalid.
+    """
+    secret = config.get("secret")
+    if not secret:
+        return True
+
+    if x_webhook_secret:
+        # Simple secret comparison
+        if x_webhook_secret != secret:
+            raise HTTPException(status_code=401, detail="Invalid secret")
+        return True
+
+    if x_signature:
+        # HMAC signature verification (GitHub style)
+        expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        expected_header = f"sha256={expected}"
+        if not hmac.compare_digest(expected_header, x_signature):
+            raise HTTPException(status_code=401, detail="Invalid signature")
+        return True
+
+    # Secret required but not provided
+    raise HTTPException(status_code=401, detail="Authentication required")
+
+
+@router.post("/{path:path}")
+async def handle_webhook(
+    path: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    x_webhook_secret: str | None = Header(None, alias="X-Webhook-Secret"),
+    x_signature: str | None = Header(None, alias="X-Hub-Signature-256"),
+) -> dict[str, Any]:
+    """Handle incoming webhook requests.
+
+    Args:
+        path: The webhook path.
+        request: The incoming request.
+        background_tasks: FastAPI background tasks.
+        x_webhook_secret: Simple secret header.
+        x_signature: HMAC signature header (GitHub style).
+
+    Returns:
+        Dictionary with execution status and ID.
+    """
+    full_path = "/" + path
+
+    if full_path not in _webhooks:
+        raise HTTPException(status_code=404, detail="Webhook not found")
+
+    config = _webhooks[full_path]
+
+    # Get request body for verification
+    body = await request.body()
+
+    # Verify secret/signature if configured
+    _verify_secret(config, body, x_webhook_secret, x_signature)
+
+    # Parse request body
+    try:
+        body_json = (await request.json()) if body else {}
+    except Exception:
+        body_json = {}
+
+    # Build workflow inputs from request
+    inputs = {
+        "_webhook": {
+            "path": full_path,
+            "method": request.method,
+            "headers": dict(request.headers),
+            "query": dict(request.query_params),
+            "body": body_json,
+            "client_ip": request.client.host if request.client else None,
+            "timestamp": datetime.now().isoformat(),
+        }
+    }
+
+    # Generate execution ID
+    execution_id = str(uuid.uuid4())
+
+    # Execute workflow in background
+    background_tasks.add_task(
+        _execute_webhook_workflow,
+        config["workflow_name"],
+        config["workflow_path"],
+        inputs,
+        execution_id,
+    )
+
+    logger.info(
+        f"Webhook triggered workflow '{config['workflow_name']}' (execution_id={execution_id})"
+    )
+
+    return {
+        "status": "accepted",
+        "execution_id": execution_id,
+        "workflow": config["workflow_name"],
+    }
+
+
+async def _execute_webhook_workflow(
+    workflow_name: str,
+    workflow_path: str,
+    inputs: dict[str, Any],
+    execution_id: str,
+) -> None:
+    """Execute a workflow triggered by a webhook.
+
+    Args:
+        workflow_name: Name of the workflow.
+        workflow_path: Path to the workflow file.
+        inputs: Workflow inputs including webhook data.
+        execution_id: Execution identifier.
+    """
+    from flowpilot.engine.parser import WorkflowParser
+
+    if _global_runner is None:
+        logger.error(f"Cannot execute workflow '{workflow_name}': no runner configured")
+        return
+
+    path = Path(workflow_path)
+    if not path.exists():
+        logger.error(f"Workflow file not found: {path}")
+        return
+
+    try:
+        parser = WorkflowParser()
+        workflow = parser.parse_file(path)
+
+        logger.info(f"Executing webhook workflow: {workflow_name}")
+
+        await _global_runner.run(
+            workflow,
+            inputs=inputs,
+            workflow_path=str(path),
+            trigger_type="webhook",
+        )
+
+        logger.info(f"Completed webhook workflow: {workflow_name}")
+
+    except Exception as e:
+        logger.exception(f"Failed to execute webhook workflow '{workflow_name}': {e}")

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,430 @@
+"""Tests for webhook handling."""
+
+import hashlib
+import hmac
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from flowpilot.api.webhooks import (
+    _verify_secret,
+    get_webhook,
+    get_webhooks,
+    register_webhook,
+    router,
+    set_global_webhook_runner,
+    unregister_webhook,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_webhooks():
+    """Clear webhooks before and after each test."""
+    from flowpilot.api import webhooks
+
+    webhooks._webhooks.clear()
+    webhooks._global_runner = None
+    yield
+    webhooks._webhooks.clear()
+    webhooks._global_runner = None
+
+
+class TestRegisterWebhook:
+    """Tests for register_webhook function."""
+
+    def test_register_webhook_with_leading_slash(self) -> None:
+        """Test registering a webhook with leading slash."""
+        path = register_webhook("/github-push", "my-workflow", "/path/to/workflow.yaml")
+
+        assert path == "/github-push"
+        webhooks = get_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["path"] == "/github-push"
+        assert webhooks[0]["workflow_name"] == "my-workflow"
+
+    def test_register_webhook_without_leading_slash(self) -> None:
+        """Test registering a webhook without leading slash adds it."""
+        path = register_webhook("github-push", "my-workflow", "/path/to/workflow.yaml")
+
+        assert path == "/github-push"
+
+    def test_register_webhook_with_secret(self) -> None:
+        """Test registering a webhook with secret."""
+        register_webhook(
+            "/secure-hook",
+            "my-workflow",
+            "/path/to/workflow.yaml",
+            secret="my-secret",
+        )
+
+        webhooks = get_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["has_secret"] is True
+
+    def test_register_webhook_without_secret(self) -> None:
+        """Test registering a webhook without secret."""
+        register_webhook("/open-hook", "my-workflow", "/path/to/workflow.yaml")
+
+        webhooks = get_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["has_secret"] is False
+
+    def test_register_multiple_webhooks(self) -> None:
+        """Test registering multiple webhooks."""
+        register_webhook("/hook1", "workflow-1", "/path/to/workflow1.yaml")
+        register_webhook("/hook2", "workflow-2", "/path/to/workflow2.yaml")
+
+        webhooks = get_webhooks()
+        assert len(webhooks) == 2
+
+
+class TestUnregisterWebhook:
+    """Tests for unregister_webhook function."""
+
+    def test_unregister_existing_webhook(self) -> None:
+        """Test unregistering an existing webhook."""
+        register_webhook("/my-hook", "my-workflow", "/path/to/workflow.yaml")
+        assert len(get_webhooks()) == 1
+
+        result = unregister_webhook("my-workflow")
+
+        assert result is True
+        assert len(get_webhooks()) == 0
+
+    def test_unregister_nonexistent_webhook(self) -> None:
+        """Test unregistering a non-existent webhook returns False."""
+        result = unregister_webhook("nonexistent")
+
+        assert result is False
+
+    def test_unregister_removes_all_webhooks_for_workflow(self) -> None:
+        """Test unregistering removes all webhooks for a workflow."""
+        register_webhook("/hook1", "my-workflow", "/path/to/workflow.yaml")
+        register_webhook("/hook2", "my-workflow", "/path/to/workflow.yaml")
+        register_webhook("/hook3", "other-workflow", "/path/to/other.yaml")
+
+        result = unregister_webhook("my-workflow")
+
+        assert result is True
+        webhooks = get_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["workflow_name"] == "other-workflow"
+
+
+class TestGetWebhooks:
+    """Tests for get_webhooks function."""
+
+    def test_get_webhooks_empty(self) -> None:
+        """Test getting webhooks when none registered."""
+        webhooks = get_webhooks()
+
+        assert webhooks == []
+
+    def test_get_webhooks_returns_list(self) -> None:
+        """Test get_webhooks returns proper format."""
+        register_webhook("/hook", "workflow", "/path.yaml", secret="secret")
+
+        webhooks = get_webhooks()
+
+        assert len(webhooks) == 1
+        assert webhooks[0] == {
+            "path": "/hook",
+            "workflow_name": "workflow",
+            "has_secret": True,
+        }
+
+
+class TestGetWebhook:
+    """Tests for get_webhook function."""
+
+    def test_get_webhook_existing(self) -> None:
+        """Test getting an existing webhook."""
+        register_webhook("/my-hook", "my-workflow", "/path.yaml")
+
+        webhook = get_webhook("my-workflow")
+
+        assert webhook is not None
+        assert webhook["path"] == "/my-hook"
+        assert webhook["workflow_name"] == "my-workflow"
+
+    def test_get_webhook_nonexistent(self) -> None:
+        """Test getting a non-existent webhook returns None."""
+        webhook = get_webhook("nonexistent")
+
+        assert webhook is None
+
+
+class TestSetGlobalWebhookRunner:
+    """Tests for set_global_webhook_runner function."""
+
+    def test_set_runner(self) -> None:
+        """Test setting the global runner."""
+        mock_runner = MagicMock()
+        set_global_webhook_runner(mock_runner)
+
+        from flowpilot.api import webhooks
+
+        assert webhooks._global_runner == mock_runner
+
+    def test_clear_runner(self) -> None:
+        """Test clearing the global runner."""
+        mock_runner = MagicMock()
+        set_global_webhook_runner(mock_runner)
+        set_global_webhook_runner(None)
+
+        from flowpilot.api import webhooks
+
+        assert webhooks._global_runner is None
+
+
+class TestVerifySecret:
+    """Tests for _verify_secret function."""
+
+    def test_no_secret_configured(self) -> None:
+        """Test verification passes when no secret configured."""
+        config = {"secret": None}
+
+        result = _verify_secret(config, b"body", None, None)
+
+        assert result is True
+
+    def test_simple_secret_valid(self) -> None:
+        """Test verification passes with valid simple secret."""
+        config = {"secret": "my-secret"}
+
+        result = _verify_secret(config, b"body", "my-secret", None)
+
+        assert result is True
+
+    def test_simple_secret_invalid(self) -> None:
+        """Test verification fails with invalid simple secret."""
+        config = {"secret": "my-secret"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            _verify_secret(config, b"body", "wrong-secret", None)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid secret"
+
+    def test_hmac_signature_valid(self) -> None:
+        """Test verification passes with valid HMAC signature."""
+        secret = "my-secret"
+        body = b'{"action": "push"}'
+        expected_sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        signature = f"sha256={expected_sig}"
+
+        config = {"secret": secret}
+        result = _verify_secret(config, body, None, signature)
+
+        assert result is True
+
+    def test_hmac_signature_invalid(self) -> None:
+        """Test verification fails with invalid HMAC signature."""
+        config = {"secret": "my-secret"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            _verify_secret(config, b"body", None, "sha256=invalid")
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid signature"
+
+    def test_secret_required_but_missing(self) -> None:
+        """Test verification fails when secret required but not provided."""
+        config = {"secret": "my-secret"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            _verify_secret(config, b"body", None, None)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Authentication required"
+
+
+class TestWebhookEndpoint:
+    """Tests for webhook HTTP endpoint."""
+
+    @pytest.fixture
+    def app(self):
+        """Create a FastAPI app with the webhook router."""
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        """Create a test client."""
+        return TestClient(app)
+
+    def test_webhook_not_found(self, client) -> None:
+        """Test 404 when webhook not found."""
+        response = client.post("/hooks/nonexistent")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Webhook not found"
+
+    def test_webhook_triggers_workflow(self, client) -> None:
+        """Test webhook triggers workflow execution."""
+        register_webhook("/my-hook", "my-workflow", "/path/to/workflow.yaml")
+
+        response = client.post(
+            "/hooks/my-hook",
+            json={"event": "push"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "accepted"
+        assert data["workflow"] == "my-workflow"
+        assert "execution_id" in data
+
+    def test_webhook_with_valid_secret(self, client) -> None:
+        """Test webhook with valid secret header."""
+        register_webhook("/secure", "my-workflow", "/path.yaml", secret="my-secret")
+
+        response = client.post(
+            "/hooks/secure",
+            json={"event": "push"},
+            headers={"X-Webhook-Secret": "my-secret"},
+        )
+
+        assert response.status_code == 200
+
+    def test_webhook_with_invalid_secret(self, client) -> None:
+        """Test webhook with invalid secret returns 401."""
+        register_webhook("/secure", "my-workflow", "/path.yaml", secret="my-secret")
+
+        response = client.post(
+            "/hooks/secure",
+            json={"event": "push"},
+            headers={"X-Webhook-Secret": "wrong-secret"},
+        )
+
+        assert response.status_code == 401
+
+    def test_webhook_with_hmac_signature(self, client) -> None:
+        """Test webhook with HMAC signature (GitHub style)."""
+        secret = "github-secret"
+        register_webhook("/github", "my-workflow", "/path.yaml", secret=secret)
+
+        body = b'{"action": "push"}'
+        signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+        response = client.post(
+            "/hooks/github",
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Hub-Signature-256": f"sha256={signature}",
+            },
+        )
+
+        assert response.status_code == 200
+
+    def test_webhook_missing_auth_when_required(self, client) -> None:
+        """Test webhook returns 401 when auth required but not provided."""
+        register_webhook("/secure", "my-workflow", "/path.yaml", secret="my-secret")
+
+        response = client.post(
+            "/hooks/secure",
+            json={"event": "push"},
+        )
+
+        assert response.status_code == 401
+
+    def test_webhook_includes_request_data_in_inputs(self, client) -> None:
+        """Test webhook passes request data to workflow inputs."""
+        register_webhook("/my-hook", "my-workflow", "/path.yaml")
+
+        # We can't easily verify inputs without mocking the runner
+        # But we can verify the response structure
+        response = client.post(
+            "/hooks/my-hook",
+            json={"event": "push", "repository": "test/repo"},
+            params={"ref": "main"},
+        )
+
+        assert response.status_code == 200
+
+    def test_webhook_empty_body(self, client) -> None:
+        """Test webhook handles empty body."""
+        register_webhook("/my-hook", "my-workflow", "/path.yaml")
+
+        response = client.post("/hooks/my-hook")
+
+        assert response.status_code == 200
+
+
+class TestWebhookExecution:
+    """Tests for webhook workflow execution."""
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_no_runner(self) -> None:
+        """Test execution logs error when no runner configured."""
+        from flowpilot.api.webhooks import _execute_webhook_workflow
+
+        with patch("flowpilot.api.webhooks.logger") as mock_logger:
+            await _execute_webhook_workflow(
+                "my-workflow",
+                "/path/to/workflow.yaml",
+                {},
+                "exec-123",
+            )
+
+            mock_logger.error.assert_called_once()
+            assert "no runner configured" in mock_logger.error.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_file_not_found(self, tmp_path) -> None:
+        """Test execution logs error when workflow file not found."""
+        from flowpilot.api.webhooks import _execute_webhook_workflow
+
+        mock_runner = MagicMock()
+        set_global_webhook_runner(mock_runner)
+
+        with patch("flowpilot.api.webhooks.logger") as mock_logger:
+            await _execute_webhook_workflow(
+                "my-workflow",
+                "/nonexistent/workflow.yaml",
+                {},
+                "exec-123",
+            )
+
+            mock_logger.error.assert_called_once()
+            assert "not found" in mock_logger.error.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_success(self, tmp_path) -> None:
+        """Test successful workflow execution."""
+        from flowpilot.api.webhooks import _execute_webhook_workflow
+
+        # Create a workflow file
+        workflow_path = tmp_path / "workflow.yaml"
+        workflow_path.write_text("""
+name: test-workflow
+triggers:
+  - type: webhook
+    path: /test
+nodes:
+  - id: delay
+    type: delay
+    duration: "1ms"
+""")
+
+        mock_runner = MagicMock()
+        mock_runner.run = AsyncMock()
+        set_global_webhook_runner(mock_runner)
+
+        await _execute_webhook_workflow(
+            "test-workflow",
+            str(workflow_path),
+            {"_webhook": {"path": "/test"}},
+            "exec-123",
+        )
+
+        mock_runner.run.assert_called_once()
+        call_kwargs = mock_runner.run.call_args[1]
+        assert call_kwargs["trigger_type"] == "webhook"
+        assert "_webhook" in call_kwargs["inputs"]


### PR DESCRIPTION
## Summary

- Add webhook trigger support for HTTP-triggered workflow execution
- FastAPI router with authentication (simple secrets and HMAC SHA256)
- Environment variable resolution for secrets (`${VAR}` syntax)
- CLI integration to display webhook status

## Changes

### New Files
- `src/flowpilot/api/webhooks.py` - Webhook router, registry, and handler
- `tests/test_webhooks.py` - 31 unit tests for webhook functionality

### Modified Files
- `src/flowpilot/api/__init__.py` - Export webhook functions
- `src/flowpilot/scheduler/manager.py` - Handle webhook triggers in enable/disable/status
- `src/flowpilot/cli/commands/schedule.py` - Display webhook info in CLI

## Features

- **Webhook Registration**: Register POST endpoints at `/hooks/{path}`
- **Secret Verification**: 
  - Simple `X-Webhook-Secret` header
  - HMAC SHA256 `X-Hub-Signature-256` (GitHub style)
- **Environment Variable Secrets**: `${SECRET_NAME}` syntax resolves from env
- **Background Execution**: Workflows run asynchronously via FastAPI BackgroundTasks
- **CLI Integration**: 
  - `flowpilot enable` shows registered webhooks
  - `flowpilot disable` removes webhooks
  - `flowpilot status` displays webhook trigger type

## Test plan

- [x] 31 unit tests pass
- [x] All 345 tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)