### PR TITLE
feat: Phase 3.2 - Claude API Node

### DIFF
--- a/src/flowpilot/config.py
+++ b/src/flowpilot/config.py
@@ -1,0 +1,77 @@
+"""Configuration management for FlowPilot."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import yaml
+
+
+class ConfigError(Exception):
+    """Error loading or accessing configuration."""
+
+
+def get_anthropic_api_key() -> str:
+    """Get Anthropic API key from various sources.
+
+    Checks in order of priority:
+    1. ANTHROPIC_API_KEY environment variable
+    2. FlowPilot config file (~/.flowpilot/config.yaml)
+    3. Claude CLI config (~/.claude/config.json)
+
+    Returns:
+        The API key string.
+
+    Raises:
+        ConfigError: If no API key is found.
+    """
+    # 1. Environment variable (highest priority)
+    if key := os.environ.get("ANTHROPIC_API_KEY"):
+        return key
+
+    # 2. FlowPilot config file
+    config_path = Path.home() / ".flowpilot" / "config.yaml"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config = yaml.safe_load(f)
+                if config and (key := config.get("anthropic", {}).get("api_key")):
+                    return str(key)
+        except (yaml.YAMLError, OSError):
+            pass  # Fall through to next option
+
+    # 3. Claude CLI config (if exists)
+    claude_config = Path.home() / ".claude" / "config.json"
+    if claude_config.exists():
+        try:
+            with open(claude_config) as f:
+                config = json.load(f)
+                if key := config.get("api_key"):
+                    return str(key)
+        except (json.JSONDecodeError, OSError):
+            pass  # Fall through to error
+
+    raise ConfigError(
+        "Anthropic API key not found. Set ANTHROPIC_API_KEY environment variable "
+        "or add to ~/.flowpilot/config.yaml under 'anthropic.api_key'"
+    )
+
+
+def get_flowpilot_config() -> dict[str, object]:
+    """Load FlowPilot configuration file.
+
+    Returns:
+        Configuration dictionary, empty if file doesn't exist.
+    """
+    config_path = Path.home() / ".flowpilot" / "config.yaml"
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+            return config if isinstance(config, dict) else {}
+    except (yaml.YAMLError, OSError):
+        return {}

--- a/src/flowpilot/engine/nodes/__init__.py
+++ b/src/flowpilot/engine/nodes/__init__.py
@@ -1,5 +1,6 @@
 """Node executor implementations for FlowPilot."""
 
+from .claude_api import ClaudeApiExecutor
 from .claude_cli import ClaudeCliExecutor
 from .condition import ConditionExecutor
 from .file_read import FileReadExecutor
@@ -8,6 +9,7 @@ from .http import HttpExecutor
 from .shell import ShellExecutor
 
 __all__ = [
+    "ClaudeApiExecutor",
     "ClaudeCliExecutor",
     "ConditionExecutor",
     "FileReadExecutor",

--- a/src/flowpilot/engine/nodes/claude_api.py
+++ b/src/flowpilot/engine/nodes/claude_api.py
@@ -1,0 +1,249 @@
+"""Claude API node executor for FlowPilot."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import anthropic
+
+from flowpilot.config import ConfigError, get_anthropic_api_key
+from flowpilot.engine.context import NodeResult
+from flowpilot.engine.executor import ExecutorRegistry, NodeExecutor
+
+if TYPE_CHECKING:
+    from flowpilot.engine.context import ExecutionContext
+    from flowpilot.models import ClaudeApiNode
+
+# Model pricing (per 1M tokens) - as of 2024/2025
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "claude-3-opus-20240229": {"input": 15.00, "output": 75.00},
+    "claude-3-sonnet-20240229": {"input": 3.00, "output": 15.00},
+    "claude-3-haiku-20240307": {"input": 0.25, "output": 1.25},
+    "claude-3-5-sonnet-20241022": {"input": 3.00, "output": 15.00},
+    "claude-3-5-haiku-20241022": {"input": 1.00, "output": 5.00},
+    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+    "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
+}
+
+# Default pricing for unknown models
+DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
+
+
+@ExecutorRegistry.register("claude-api")
+class ClaudeApiExecutor(NodeExecutor):
+    """Execute prompts via Anthropic API directly."""
+
+    def __init__(self) -> None:
+        """Initialize the executor."""
+        self._client: anthropic.AsyncAnthropic | None = None
+
+    def _get_client(self) -> anthropic.AsyncAnthropic:
+        """Get or create Anthropic async client.
+
+        Returns:
+            AsyncAnthropic client instance.
+
+        Raises:
+            ConfigError: If API key is not configured.
+        """
+        if self._client is None:
+            api_key = get_anthropic_api_key()
+            self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        return self._client
+
+    async def execute(
+        self,
+        node: ClaudeApiNode,  # type: ignore[override]
+        context: ExecutionContext,
+    ) -> NodeResult:
+        """Execute a prompt via Anthropic API.
+
+        Args:
+            node: The claude-api node to execute.
+            context: The execution context.
+
+        Returns:
+            NodeResult with API response.
+        """
+        started_at = datetime.now()
+
+        try:
+            client = self._get_client()
+        except ConfigError as e:
+            return NodeResult(
+                status="error",
+                error_message=str(e),
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+        # Build messages
+        messages = node.messages or [{"role": "user", "content": node.prompt}]
+
+        # Build request kwargs
+        kwargs: dict[str, Any] = {
+            "model": node.model,
+            "max_tokens": node.max_tokens,
+            "messages": messages,
+        }
+
+        # System prompt handling
+        system_prompt = node.system
+
+        # JSON mode - add instruction to system prompt
+        if node.output_format == "json":
+            json_instruction = "\n\nRespond with valid JSON only."
+            if node.json_schema:
+                json_instruction += f" Use this schema: {json.dumps(node.json_schema)}"
+
+            if system_prompt:
+                system_prompt += json_instruction
+            else:
+                system_prompt = json_instruction.strip()
+
+        if system_prompt:
+            kwargs["system"] = system_prompt
+
+        # Optional generation parameters
+        if node.temperature is not None:
+            kwargs["temperature"] = node.temperature
+
+        if node.top_p is not None:
+            kwargs["top_p"] = node.top_p
+
+        if node.top_k is not None:
+            kwargs["top_k"] = node.top_k
+
+        if node.stop_sequences:
+            kwargs["stop_sequences"] = node.stop_sequences
+
+        if node.metadata:
+            kwargs["metadata"] = {"user_id": node.metadata.get("user_id", "")}
+
+        try:
+            # Make API call with timeout
+            response = await asyncio.wait_for(
+                client.messages.create(**kwargs),
+                timeout=node.timeout,
+            )
+
+            # Extract response text
+            output_text = ""
+            for block in response.content:
+                if block.type == "text":
+                    output_text += block.text
+
+            # Parse JSON if requested
+            parsed_data: dict[str, Any] | None = None
+            if node.output_format == "json":
+                try:
+                    parsed_data = json.loads(output_text)
+                except json.JSONDecodeError as e:
+                    parsed_data = {"parse_error": str(e), "raw": output_text}
+
+            # Calculate cost
+            input_tokens = response.usage.input_tokens
+            output_tokens = response.usage.output_tokens
+            cost = self._calculate_cost(node.model, input_tokens, output_tokens)
+
+            return NodeResult(
+                status="success",
+                output=output_text,
+                data={
+                    "model": node.model,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                    "cost_usd": cost,
+                    "stop_reason": response.stop_reason,
+                    "parsed": parsed_data,
+                },
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+        except anthropic.APIConnectionError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"API connection error: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except anthropic.RateLimitError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Rate limit exceeded: {e}. Retry after delay.",
+                data={"retry_after": getattr(e, "retry_after", 60)},
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except anthropic.APIStatusError as e:
+            return NodeResult(
+                status="error",
+                error_message=f"API error ({e.status_code}): {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except TimeoutError:
+            return NodeResult(
+                status="error",
+                error_message=f"API request timed out after {node.timeout}s",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+        except Exception as e:
+            return NodeResult(
+                status="error",
+                error_message=f"Unexpected error: {e}",
+                duration_ms=self._duration_ms(started_at),
+                started_at=started_at,
+                finished_at=datetime.now(),
+            )
+
+    def _calculate_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> float:
+        """Calculate API cost in USD.
+
+        Args:
+            model: The model ID.
+            input_tokens: Number of input tokens.
+            output_tokens: Number of output tokens.
+
+        Returns:
+            Estimated cost in USD.
+        """
+        # Find pricing for model (exact match or prefix match)
+        pricing = MODEL_PRICING.get(model)
+
+        if not pricing:
+            # Try prefix matching for versioned models
+            for model_name, price in MODEL_PRICING.items():
+                if model.startswith(model_name.rsplit("-", 1)[0]):
+                    pricing = price
+                    break
+
+        if not pricing:
+            pricing = DEFAULT_PRICING
+
+        input_cost = (input_tokens / 1_000_000) * pricing["input"]
+        output_cost = (output_tokens / 1_000_000) * pricing["output"]
+
+        return round(input_cost + output_cost, 6)
+
+    @staticmethod
+    def _duration_ms(started_at: datetime) -> int:
+        """Calculate duration in milliseconds."""
+        return int((datetime.now() - started_at).total_seconds() * 1000)

--- a/src/flowpilot/models/nodes.py
+++ b/src/flowpilot/models/nodes.py
@@ -120,16 +120,38 @@ class ClaudeCliNode(BaseNode):
 
 
 class ClaudeApiNode(BaseNode):
-    """Call Claude API directly."""
+    """Call Claude API directly via Anthropic SDK."""
 
     type: Literal["claude-api"]
-    prompt: str = Field(..., description="Prompt to send")
-    model: str = Field(default="claude-sonnet-4-20250514", description="Model ID")
+    prompt: str = Field(..., description="User message (Jinja2 templated)")
+
+    # Model configuration
+    model: str = Field(default="claude-sonnet-4-20250514", description="Claude model ID")
+
+    # System prompt
     system: str | None = Field(default=None, description="System prompt")
-    max_tokens: int = Field(default=4096, ge=1, description="Maximum tokens")
+
+    # Generation parameters
+    max_tokens: int = Field(default=4096, ge=1, description="Maximum tokens for response")
     temperature: float | None = Field(default=None, ge=0.0, le=1.0, description="Temperature")
-    timeout: int = Field(default=120, ge=1, description="Timeout in seconds")
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0, description="Top-p sampling")
+    top_k: int | None = Field(default=None, ge=1, description="Top-k sampling")
+
+    # Output control
+    stop_sequences: list[str] | None = Field(default=None, description="Stop sequences")
     output_format: Literal["text", "json"] = Field(default="text", description="Output format")
+    json_schema: dict[str, Any] | None = Field(default=None, description="JSON schema for output")
+
+    # Execution
+    timeout: int = Field(default=120, ge=1, description="API timeout in seconds")
+
+    # Advanced
+    metadata: dict[str, str] | None = Field(default=None, description="Request metadata")
+
+    # Multi-turn (within same node execution)
+    messages: list[dict[str, Any]] | None = Field(
+        default=None, description="Override with full message history"
+    )
 
 
 # Union type for all nodes with discriminator

--- a/tests/fixtures/claude_api_workflow.yaml
+++ b/tests/fixtures/claude_api_workflow.yaml
@@ -1,0 +1,68 @@
+# Example workflow using Claude API node
+name: claude-api-test
+description: Test workflow for Claude API integration
+
+triggers:
+  - type: manual
+
+inputs:
+  text:
+    type: string
+    description: Text to process
+    default: "Hello, world!"
+
+nodes:
+  # Simple API call
+  - id: simple-call
+    type: claude-api
+    prompt: "Say hello back: {{ inputs.text }}"
+    max_tokens: 100
+
+  # Call with system prompt
+  - id: with-system
+    type: claude-api
+    prompt: "What is 2+2?"
+    system: "You are a math tutor. Be concise."
+    temperature: 0.3
+    depends_on:
+      - simple-call
+
+  # JSON output
+  - id: json-output
+    type: claude-api
+    prompt: "Extract any numbers from: {{ inputs.text }}"
+    output_format: json
+    json_schema:
+      type: object
+      properties:
+        numbers:
+          type: array
+          items:
+            type: number
+    depends_on:
+      - with-system
+
+  # Using different model
+  - id: haiku-call
+    type: claude-api
+    prompt: "Summarize in one word: {{ nodes.simple_call.output }}"
+    model: claude-3-haiku-20240307
+    max_tokens: 10
+    depends_on:
+      - simple-call
+
+  # With all parameters
+  - id: full-params
+    type: claude-api
+    prompt: "Generate a creative response"
+    model: claude-sonnet-4-20250514
+    system: "You are creative and helpful."
+    max_tokens: 500
+    temperature: 0.8
+    top_p: 0.95
+    stop_sequences:
+      - "END"
+      - "DONE"
+    timeout: 60
+    depends_on:
+      - haiku-call

--- a/tests/test_nodes_claude_api.py
+++ b/tests/test_nodes_claude_api.py
@@ -1,0 +1,770 @@
+"""Tests for Claude API node executor."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import anthropic
+import pytest
+
+from flowpilot.config import ConfigError, get_anthropic_api_key
+from flowpilot.engine.context import ExecutionContext
+from flowpilot.engine.nodes.claude_api import (
+    DEFAULT_PRICING,
+    ClaudeApiExecutor,
+)
+from flowpilot.models import ClaudeApiNode
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def executor() -> ClaudeApiExecutor:
+    """Create a fresh executor instance."""
+    return ClaudeApiExecutor()
+
+
+@pytest.fixture
+def context() -> ExecutionContext:
+    """Create a basic execution context."""
+    return ExecutionContext(workflow_name="test-workflow")
+
+
+@pytest.fixture
+def basic_node() -> ClaudeApiNode:
+    """Create a basic claude-api node."""
+    return ClaudeApiNode(
+        id="test-api",
+        type="claude-api",
+        prompt="Hello, Claude!",
+    )
+
+
+@pytest.fixture
+def mock_response() -> MagicMock:
+    """Create a mock API response."""
+    response = MagicMock()
+    response.content = [MagicMock(type="text", text="Hello! How can I help you?")]
+    response.usage = MagicMock(input_tokens=10, output_tokens=20)
+    response.stop_reason = "end_turn"
+    return response
+
+
+# ============================================================================
+# Config Tests
+# ============================================================================
+
+
+class TestApiKeyConfig:
+    """Tests for API key configuration."""
+
+    def test_get_api_key_from_env(self) -> None:
+        """Test getting API key from environment variable."""
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key-123"}):
+            key = get_anthropic_api_key()
+            assert key == "test-key-123"
+
+    def test_get_api_key_missing_raises_error(self) -> None:
+        """Test that missing API key raises ConfigError."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            # Clear the environment variable if it exists
+            import os
+
+            env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+            try:
+                with pytest.raises(ConfigError, match="API key not found"):
+                    get_anthropic_api_key()
+            finally:
+                if env_backup:
+                    os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+    def test_get_api_key_from_flowpilot_config(self) -> None:
+        """Test getting API key from FlowPilot config file."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("pathlib.Path.exists") as mock_exists,
+            patch("builtins.open", MagicMock()),
+            patch("yaml.safe_load", return_value={"anthropic": {"api_key": "config-key-456"}}),
+        ):
+            import os
+
+            env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+            mock_exists.return_value = True
+            try:
+                key = get_anthropic_api_key()
+                assert key == "config-key-456"
+            finally:
+                if env_backup:
+                    os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+
+# ============================================================================
+# Executor Tests
+# ============================================================================
+
+
+class TestClaudeApiExecutor:
+    """Tests for ClaudeApiExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_successful_execution(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test successful API execution."""
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch.object(
+                anthropic.AsyncAnthropic,
+                "messages",
+                new_callable=lambda: MagicMock(create=AsyncMock(return_value=mock_response)),
+            ),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "success"
+            assert result.output == "Hello! How can I help you?"
+            assert result.data["input_tokens"] == 10
+            assert result.data["output_tokens"] == 20
+            assert result.data["total_tokens"] == 30
+            assert result.data["stop_reason"] == "end_turn"
+            assert "cost_usd" in result.data
+
+    @pytest.mark.asyncio
+    async def test_execution_with_system_prompt(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test execution with system prompt."""
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Hello!",
+            system="You are a helpful assistant.",
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            # Verify system prompt was passed
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["system"] == "You are a helpful assistant."
+
+    @pytest.mark.asyncio
+    async def test_execution_with_temperature(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test execution with temperature parameter."""
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Hello!",
+            temperature=0.7,
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_execution_with_all_generation_params(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test execution with all generation parameters."""
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Hello!",
+            temperature=0.5,
+            top_p=0.9,
+            top_k=50,
+            max_tokens=1000,
+            stop_sequences=["END", "STOP"],
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["temperature"] == 0.5
+            assert call_kwargs["top_p"] == 0.9
+            assert call_kwargs["top_k"] == 50
+            assert call_kwargs["max_tokens"] == 1000
+            assert call_kwargs["stop_sequences"] == ["END", "STOP"]
+
+    @pytest.mark.asyncio
+    async def test_json_output_format(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+    ) -> None:
+        """Test JSON output format parsing."""
+        json_response = {"name": "Claude", "type": "AI"}
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text=json.dumps(json_response))]
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=20)
+        mock_response.stop_reason = "end_turn"
+
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Return JSON",
+            output_format="json",
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            assert result.data["parsed"] == json_response
+            # Verify JSON instruction was added to system
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert "valid JSON" in call_kwargs.get("system", "")
+
+    @pytest.mark.asyncio
+    async def test_json_output_with_schema(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+    ) -> None:
+        """Test JSON output with schema hint."""
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Return JSON",
+            output_format="json",
+            json_schema=schema,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text='{"name": "test"}')]
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=20)
+        mock_response.stop_reason = "end_turn"
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            # Verify schema was included in system prompt
+            assert "schema" in call_kwargs.get("system", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_json_parse_error(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+    ) -> None:
+        """Test JSON parse error handling."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text="not valid json")]
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=20)
+        mock_response.stop_reason = "end_turn"
+
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Return JSON",
+            output_format="json",
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"  # Still success, just with parse error
+            assert "parse_error" in result.data["parsed"]
+            assert result.data["parsed"]["raw"] == "not valid json"
+
+    @pytest.mark.asyncio
+    async def test_custom_messages(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test execution with custom message history."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="This is ignored",
+            messages=messages,
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "success"
+            call_kwargs = mock_client.messages.create.call_args.kwargs
+            assert call_kwargs["messages"] == messages
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+    ) -> None:
+        """Test error when API key is missing."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("pathlib.Path.exists", return_value=False),
+        ):
+            import os
+
+            env_backup = os.environ.pop("ANTHROPIC_API_KEY", None)
+            try:
+                result = await executor.execute(basic_node, context)
+
+                assert result.status == "error"
+                assert "API key not found" in str(result.error_message)
+            finally:
+                if env_backup:
+                    os.environ["ANTHROPIC_API_KEY"] = env_backup
+
+    @pytest.mark.asyncio
+    async def test_connection_error(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+    ) -> None:
+        """Test API connection error handling."""
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(
+            create=AsyncMock(side_effect=anthropic.APIConnectionError(request=MagicMock()))
+        )
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "error"
+            assert "connection error" in str(result.error_message).lower()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+    ) -> None:
+        """Test rate limit error handling."""
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {}
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(
+            create=AsyncMock(
+                side_effect=anthropic.RateLimitError(
+                    message="Rate limit exceeded",
+                    response=mock_response,
+                    body=None,
+                )
+            )
+        )
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "error"
+            assert "rate limit" in str(result.error_message).lower()
+            assert "retry_after" in result.data
+
+    @pytest.mark.asyncio
+    async def test_api_status_error(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+    ) -> None:
+        """Test API status error handling."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.headers = {}
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(
+            create=AsyncMock(
+                side_effect=anthropic.APIStatusError(
+                    message="Internal server error",
+                    response=mock_response,
+                    body=None,
+                )
+            )
+        )
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "error"
+            assert "500" in str(result.error_message)
+
+    @pytest.mark.asyncio
+    async def test_timeout_error(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+    ) -> None:
+        """Test timeout error handling."""
+        node = ClaudeApiNode(
+            id="test-api",
+            type="claude-api",
+            prompt="Hello!",
+            timeout=1,  # Very short timeout
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(side_effect=TimeoutError()))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(node, context)
+
+            assert result.status == "error"
+            assert "timed out" in str(result.error_message).lower()
+
+
+# ============================================================================
+# Cost Calculation Tests
+# ============================================================================
+
+
+class TestCostCalculation:
+    """Tests for cost calculation."""
+
+    def test_calculate_cost_known_model(self, executor: ClaudeApiExecutor) -> None:
+        """Test cost calculation for a known model."""
+        cost = executor._calculate_cost(
+            "claude-3-sonnet-20240229",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        # Input: 1000 / 1M * 3.00 = 0.003
+        # Output: 500 / 1M * 15.00 = 0.0075
+        # Total: 0.0105
+        assert cost == pytest.approx(0.0105, rel=0.01)
+
+    def test_calculate_cost_opus(self, executor: ClaudeApiExecutor) -> None:
+        """Test cost calculation for Opus model."""
+        cost = executor._calculate_cost(
+            "claude-3-opus-20240229",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        # Input: 1000 / 1M * 15.00 = 0.015
+        # Output: 500 / 1M * 75.00 = 0.0375
+        # Total: 0.0525
+        assert cost == pytest.approx(0.0525, rel=0.01)
+
+    def test_calculate_cost_haiku(self, executor: ClaudeApiExecutor) -> None:
+        """Test cost calculation for Haiku model."""
+        cost = executor._calculate_cost(
+            "claude-3-haiku-20240307",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        # Input: 1000 / 1M * 0.25 = 0.00025
+        # Output: 500 / 1M * 1.25 = 0.000625
+        # Total: 0.000875
+        assert cost == pytest.approx(0.000875, rel=0.01)
+
+    def test_calculate_cost_unknown_model(self, executor: ClaudeApiExecutor) -> None:
+        """Test cost calculation falls back to default for unknown model."""
+        cost = executor._calculate_cost(
+            "claude-unknown-model",
+            input_tokens=1000,
+            output_tokens=500,
+        )
+        # Uses default pricing (same as sonnet)
+        expected = (1000 / 1_000_000 * DEFAULT_PRICING["input"]) + (
+            500 / 1_000_000 * DEFAULT_PRICING["output"]
+        )
+        assert cost == pytest.approx(expected, rel=0.01)
+
+    def test_calculate_cost_zero_tokens(self, executor: ClaudeApiExecutor) -> None:
+        """Test cost calculation with zero tokens."""
+        cost = executor._calculate_cost(
+            "claude-3-sonnet-20240229",
+            input_tokens=0,
+            output_tokens=0,
+        )
+        assert cost == 0.0
+
+
+# ============================================================================
+# Node Model Tests
+# ============================================================================
+
+
+class TestClaudeApiNodeModel:
+    """Tests for ClaudeApiNode model validation."""
+
+    def test_minimal_node(self) -> None:
+        """Test creating node with minimal required fields."""
+        node = ClaudeApiNode(
+            id="test",
+            type="claude-api",
+            prompt="Hello",
+        )
+        assert node.prompt == "Hello"
+        assert node.model == "claude-sonnet-4-20250514"
+        assert node.max_tokens == 4096
+        assert node.temperature is None
+
+    def test_full_node(self) -> None:
+        """Test creating node with all fields."""
+        node = ClaudeApiNode(
+            id="test",
+            type="claude-api",
+            prompt="Hello",
+            model="claude-3-opus-20240229",
+            system="You are helpful.",
+            max_tokens=2000,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40,
+            stop_sequences=["END"],
+            output_format="json",
+            json_schema={"type": "object"},
+            timeout=60,
+            metadata={"user_id": "test-user"},
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        assert node.model == "claude-3-opus-20240229"
+        assert node.temperature == 0.7
+        assert node.top_p == 0.9
+        assert node.top_k == 40
+        assert node.output_format == "json"
+
+    def test_temperature_validation(self) -> None:
+        """Test temperature validation bounds."""
+        # Valid temperature
+        node = ClaudeApiNode(
+            id="test",
+            type="claude-api",
+            prompt="Hello",
+            temperature=0.5,
+        )
+        assert node.temperature == 0.5
+
+        # Invalid temperature (too high)
+        with pytest.raises(ValueError):
+            ClaudeApiNode(
+                id="test",
+                type="claude-api",
+                prompt="Hello",
+                temperature=1.5,
+            )
+
+        # Invalid temperature (negative)
+        with pytest.raises(ValueError):
+            ClaudeApiNode(
+                id="test",
+                type="claude-api",
+                prompt="Hello",
+                temperature=-0.1,
+            )
+
+    def test_max_tokens_validation(self) -> None:
+        """Test max_tokens validation."""
+        # Valid max_tokens
+        node = ClaudeApiNode(
+            id="test",
+            type="claude-api",
+            prompt="Hello",
+            max_tokens=100,
+        )
+        assert node.max_tokens == 100
+
+        # Invalid max_tokens (zero)
+        with pytest.raises(ValueError):
+            ClaudeApiNode(
+                id="test",
+                type="claude-api",
+                prompt="Hello",
+                max_tokens=0,
+            )
+
+    def test_timeout_validation(self) -> None:
+        """Test timeout validation."""
+        # Valid timeout
+        node = ClaudeApiNode(
+            id="test",
+            type="claude-api",
+            prompt="Hello",
+            timeout=300,
+        )
+        assert node.timeout == 300
+
+        # Invalid timeout (zero)
+        with pytest.raises(ValueError):
+            ClaudeApiNode(
+                id="test",
+                type="claude-api",
+                prompt="Hello",
+                timeout=0,
+            )
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestClaudeApiIntegration:
+    """Integration tests for Claude API executor."""
+
+    @pytest.mark.asyncio
+    async def test_executor_registered(self) -> None:
+        """Test that executor is registered in the registry."""
+        import importlib
+
+        import flowpilot.engine.nodes.claude_api as claude_api_module
+        from flowpilot.engine.executor import ExecutorRegistry
+
+        # Reload module to re-trigger registration (in case registry was cleared)
+        importlib.reload(claude_api_module)
+
+        assert ExecutorRegistry.has_executor("claude-api")
+        executor = ExecutorRegistry.get("claude-api")
+        # Check by class name since reload creates new class identity
+        assert executor.__class__.__name__ == "ClaudeApiExecutor"
+
+    @pytest.mark.asyncio
+    async def test_multiple_content_blocks(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+    ) -> None:
+        """Test handling response with multiple content blocks."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(type="text", text="Part 1"),
+            MagicMock(type="text", text=" Part 2"),
+            MagicMock(type="text", text=" Part 3"),
+        ]
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=20)
+        mock_response.stop_reason = "end_turn"
+
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "success"
+            assert result.output == "Part 1 Part 2 Part 3"
+
+    @pytest.mark.asyncio
+    async def test_result_metadata(
+        self,
+        executor: ClaudeApiExecutor,
+        context: ExecutionContext,
+        basic_node: ClaudeApiNode,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test that result contains all expected metadata."""
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock(create=AsyncMock(return_value=mock_response))
+
+        with (
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+            patch("anthropic.AsyncAnthropic", return_value=mock_client),
+        ):
+            result = await executor.execute(basic_node, context)
+
+            assert result.status == "success"
+            assert result.started_at is not None
+            assert result.finished_at is not None
+            assert result.duration_ms >= 0
+            assert "model" in result.data
+            assert "input_tokens" in result.data
+            assert "output_tokens" in result.data
+            assert "total_tokens" in result.data
+            assert "cost_usd" in result.data
+            assert "stop_reason" in result.data


### PR DESCRIPTION
## Summary
- Implement direct Anthropic API integration for fast, lightweight AI operations without CLI overhead
- Add `ClaudeApiExecutor` for direct API calls via `anthropic` SDK
- Create configuration module for API key management

## Features
- **All Claude models supported**: claude-3-opus, claude-3-sonnet, claude-3-haiku, and newer variants
- **Generation parameters**: temperature, top_p, top_k, max_tokens, stop_sequences
- **JSON output mode**: With optional schema hints for structured output
- **Token tracking**: Input/output tokens with cost estimation
- **API key sources**: Environment variable, FlowPilot config file, Claude CLI config
- **Error handling**: Rate limits (with retry info), timeouts, connection errors

## Files Changed
- `src/flowpilot/config.py` - New API key configuration management
- `src/flowpilot/engine/nodes/claude_api.py` - Claude API executor (220+ lines)
- `src/flowpilot/models/nodes.py` - Enhanced ClaudeApiNode model
- `src/flowpilot/engine/nodes/__init__.py` - Register new executor
- `tests/test_nodes_claude_api.py` - 29 comprehensive tests
- `tests/fixtures/claude_api_workflow.yaml` - Example workflow

## Test plan
- [x] All 29 new tests pass
- [x] Full test suite (372 tests) passes
- [x] Linting (ruff) passes
- [x] Type checking (mypy) passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)